### PR TITLE
use salted password encryption for regal-api roles

### DIFF
--- a/app/actions/BasicAuthAction.java
+++ b/app/actions/BasicAuthAction.java
@@ -19,6 +19,7 @@ package actions;
 import models.User;
 import play.Play;
 import play.libs.F;
+import play.Logger;
 import play.mvc.Action;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -60,6 +61,7 @@ public class BasicAuthAction extends Action<BasicAuth> {
 	    context.args.put("role", authUser.getRole());
 	    return delegate.call(context);
 	}
+	play.Logger.debug("Authentifizierung fehlgeschlagen !");
 	return unauthorized(context);
     }
 

--- a/app/models/EncryptedUser.java
+++ b/app/models/EncryptedUser.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2016 hbz NRW (http://www.hbz-nrw.de/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package models;
+
+import controllers.MyController;
+import org.apache.commons.codec.digest.DigestUtils;
+import play.Play;
+
+/**
+ * @author Ingolf Kuss, hbz
+ * @email  kuss@hbz-nrw.de
+ * 
+ */
+public class EncryptedUser implements User {
+    String role = null;
+
+    /**
+     * Dieser Nutzer zeichnet sich dadurch aus, dass er/sie sich mit verschlüsseltem Passwort anmeldet.
+     * SALT und HASH sind die hier gewählten Verschlüsselungsmethoden für das Passwort.
+     * 
+     * Das Passwort wird per https übertragen, dann von der Klasse BasicAuthAction in der Methode "call" dekodiert.
+     * Anschließend wird es an diese Klasse, Methode "authenticate" übergeben.
+     * Diese Methode liest "Salz" und Hash aus der Konfigurationsdatei "application.conf".
+     * Das der Methode übergebene Passwort wird nun "gesalzen", dann mit dem SHA-256 Algorithmus verschlüsselt,
+     * und schließlich mit dem hinterlegten verschlüsselten Passwort (Hash) verglichen. 
+     * 
+     */
+    public EncryptedUser() {
+    	
+    String adminSalt;
+    String adminHash;
+	String editorSalt;
+	String editorHash;
+	String readerSalt;
+	String readerHash;
+	String subscriberSalt;
+	String subscriberHash;
+	String remoteSalt;
+	String remoteHash;
+	
+	adminSalt = Play.application().configuration().getString("regal-api.admin-salt");
+	adminHash = Play.application().configuration().getString("regal-api.admin-hash");
+	editorSalt = Play.application().configuration().getString("regal-api.editor-salt");
+	editorHash = Play.application().configuration().getString("regal-api.editor-hash");
+	readerSalt = Play.application().configuration().getString("regal-api.reader-salt");	
+	readerHash = Play.application().configuration().getString("regal-api.reader-hash");
+	subscriberSalt = Play.application().configuration().getString("regal-api.subscriber-salt");
+	subscriberHash = Play.application().configuration().getString("regal-api.subscriber-hash");
+	remoteSalt = Play.application().configuration().getString("regal-api.remote-salt");	
+	remoteHash = Play.application().configuration().getString("regal-api.remote-hash");
+
+	if(   adminSalt == null || adminHash == null 
+	   || editorSalt == null || editorHash == null
+	   || readerSalt == null || readerHash == null
+	   || subscriberSalt == null || subscriberHash == null
+	   || remoteSalt == null || remoteHash == null ) {
+		throw new RuntimeException("Bitte in der Konfigurationsdatei SALT und HASH für die Passwörter aller Rollen hinterlegen !");
+		}
+	}
+
+    @Override
+    public User authenticate(String username, String password) {
+	role = null;
+	// "Luschi"-Rolle anonymous; geht auch ohne Passwort durch
+	if (username == null || username.isEmpty()) {
+	    role = MyController.ANONYMOUS_ROLE;
+	} else if (MyController.ANONYMOUS_ROLE.equals(username)) {
+	    role = MyController.ANONYMOUS_ROLE;
+	} else if (password == null || password.isEmpty()) {
+	    role = MyController.ANONYMOUS_ROLE;
+	}
+	if( role != null ) {
+		play.Logger.info("Sie haben sich als anonymer Benutzer angemeldet.");
+		return this;
+	}
+	
+	// ab hier geht's nur noch mit gültigem Passwort zum Erfolg;
+	// Authentifizierung mit Verschlüsselungsmechanismus SALT + HASH
+	String saltedPasswd = null;
+	String hashedPasswd = null;
+	if (MyController.ADMIN_ROLE.equals(username)) {
+		saltedPasswd = Play.application().configuration().getString("regal-api.admin-salt")+password;		
+		hashedPasswd = Play.application().configuration().getString("regal-api.admin-hash");
+	} else if (MyController.EDITOR_ROLE.equals(username)) {
+		saltedPasswd = Play.application().configuration().getString("regal-api.editor-salt")+password;		
+		hashedPasswd = Play.application().configuration().getString("regal-api.editor-hash");
+	} else if (MyController.READER_ROLE.equals(username)) {
+		saltedPasswd = Play.application().configuration().getString("regal-api.reader-salt")+password;		
+		hashedPasswd = Play.application().configuration().getString("regal-api.reader-hash");
+	} else if (MyController.SUBSCRIBER_ROLE.equals(username)) {
+		saltedPasswd = Play.application().configuration().getString("regal-api.subscriber-salt")+password;		
+		hashedPasswd = Play.application().configuration().getString("regal-api.subscriber-hash");
+	} else if (MyController.REMOTE_ROLE.equals(username)) {
+		saltedPasswd = Play.application().configuration().getString("regal-api.remote-salt")+password;		
+		hashedPasswd = Play.application().configuration().getString("regal-api.remote-hash");
+	}
+	if( saltedPasswd == null ) {
+		throw new RuntimeException("Authentifizierung ungültig !");
+	}
+	play.Logger.trace("gesalzenes Passwort: \""+saltedPasswd+"\"");
+	String encryptedPasswd = DigestUtils.sha256Hex(saltedPasswd);
+	if( ! encryptedPasswd.equals(hashedPasswd) ) {
+		play.Logger.error("Falsches Passwort für Rolle "+username+" !");
+		play.Logger.error("  erwarteter Hash:"+hashedPasswd);
+		play.Logger.error("  erzeugter  Hash:"+encryptedPasswd);
+		throw new RuntimeException("Authentifizierung ungültig !");
+	}
+	// Authentifizierung war erfolgreich
+	role = username;
+	play.Logger.trace("verschlüsseltes Passwort ist: \""+encryptedPasswd+"\"");
+	play.Logger.info("Sie haben sich erfolgreich eingeloggt als: " + role);
+	return this;
+    }
+    
+    @Override
+    public String getRole() {
+	return role;
+    }
+
+    @Override
+    public void setRole(String role) {
+	this.role = role;
+    }
+}

--- a/conf/application.conf.tmpl
+++ b/conf/application.conf.tmpl
@@ -24,17 +24,28 @@ regal-api.protocol="http://"
 regal-api.mab655x="Archivierte Online-Ressource"
 
 #---------------Auth-------------------
-#models.FakeUser or models.LdapUser or models.HardCodedUser
+#models.FakeUser or models.LdapUser or models.HardCodedUser or models.EncryptedUser
 #regal-api.userImpl="models.FakeUser" 
 #only needed if regal-api.userImpl="models.LdapUser"
 #regal-api.ldapServer="ldap://yourldapserver:389"
 #only needed if regal-api.userImpl="models.HardCodedUser"
-regal-api.userImpl="models.HardCodedUser"
-regal-api.admin-password="admin"
-regal-api.editor-password="admin"
-regal-api.reader-password="admin"
-regal-api.subscriber-password="admin"
-regal-api.remote-password="admin"
+#regal-api.userImpl="models.HardCodedUser"
+#regal-api.admin-password=
+#regal-api.editor-password=
+#regal-api.reader-password=
+#regal-api.subscriber-password=
+#regal-api.remote-password=
+regal-api.userImpl="models.EncryptedUser"
+regal-api.admin-salt="i/eH15H1lD/NirbFbXTF8IZJhOtjo9IfM9fkkHg0mHY="
+regal-api.admin-hash="1b276263590218d1ed0cd1da411e7570c3370c298745143710aa5c021f985f94"
+regal-api.editor-salt="dHreWxIEaBJMiFOINMOioC9/hbz9vQU7v9Gb1qk1fPE="
+regal-api.editor-hash="8d3092a81b450616550be426a6ad60c3b35ba8a33b08626669f05d1c807c3110"
+regal-api.reader-salt="RNwdz7Snk1Qf+dbKbNbjYxuykWIqDCbJd4Q4OkrBG+c="
+regal-api.reader-hash="dff6e1ba093335afad421270590afdd4b7b9bf904ed4ef29db9ba27a4c67f24c"
+regal-api.subscriber-salt="7de7DqDjVEVb6pMba2chP4rcGiV975Xuij3UYK4oaoQ="
+regal-api.subscriber-hash="b54df7f13221f00f757eb99ff6142f29dc1d95c34602e2aca94a78f1f7e34f22"
+regal-api.remote-salt="M7emrcXWQXb3o6EjUFDWlsztkl/2ieYqjnystKNIPUA="
+regal-api.remote-hash="1156c846b938ebba4ec4fade0b3a276b7071b4a5f13d2662b0f4200582f2862f"
 regal-api.ipWhiteList="127.0.0"
 
 #-------------Thirdparty----------------


### PR DESCRIPTION
- für jede Rolle wird ein SALT und ein HASH in application.conf(.tmpl) abgelegt
- die Passwörter im Klartext tauchen nirgendwo mehr auf, müssen auf einem Zettel notiert oder im Kopf gemerkt werden !
- neuen User "EncryptedUser" für BasicAuthentication hinzugefügt. Hier wird das (aus drupal kommende) Passwort gesalzen und verschlüsselt, dann mit dem in der Konfiguration hinterlegtem Hash verglichen.
