### PR TITLE
use different logback configuration in developer mode

### DIFF
--- a/app/Global.java
+++ b/app/Global.java
@@ -16,17 +16,26 @@
  *
  */
 import static play.mvc.Results.notFound;
-import helper.oai.OaiDispatcher;
 
+import java.io.File;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.BasicConfigurator;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.classic.util.ContextInitializer;
+import ch.qos.logback.core.joran.spi.JoranException;
+import helper.oai.OaiDispatcher;
 import models.Globals;
 import play.Application;
 import play.GlobalSettings;
+import play.Play;
 import play.libs.F.Promise;
 import play.mvc.Action;
 import play.mvc.Http.Request;
@@ -38,7 +47,6 @@ import play.mvc.Result;
  *
  */
 public class Global extends GlobalSettings {
-	@Override
 	public void onStart(Application app) {
 		try {
 			if (play.api.Play.isProd(play.api.Play.current())) {
@@ -53,6 +61,55 @@ public class Global extends GlobalSettings {
 				OaiDispatcher.initContentModels("");
 
 				Globals.search.init(Globals.namespaces);
+			} else {
+				// play Framework läuft im Test- oder Entwicklungsmodus
+				// Logger-Konfiguration für Entwicklung laden
+				// Quelle hier:
+				// http://stackoverflow.com/questions/14288623/logback-externalization
+
+				String logbackConfFilename = "conf/logback.developer.xml";
+				File logbackConfigurationFile = null;
+				try {
+					logbackConfigurationFile =
+							Play.application().getFile(logbackConfFilename);
+				} catch (Exception exception) {
+					play.Logger.error("Can't read resource {} !", logbackConfFilename,
+							exception);
+				}
+
+				if (logbackConfigurationFile.exists()) {
+
+					play.Logger.info(
+							"Found logback configuration {} - Overriding default configuration.",
+							logbackConfFilename);
+					JoranConfigurator configurator = new JoranConfigurator();
+					LoggerContext loggerContext =
+							(LoggerContext) LoggerFactory.getILoggerFactory();
+					loggerContext.reset();
+					configurator.setContext(loggerContext);
+					try {
+						configurator.doConfigure(logbackConfigurationFile);
+						play.Logger.info(
+								"Default configuration overridden by logback configuration {}.",
+								logbackConfFilename);
+					} catch (Exception exception) {
+						try {
+							new ContextInitializer(loggerContext).autoConfig();
+						} catch (JoranException e) {
+							BasicConfigurator.configureDefaultContext();
+							play.Logger.error("Can't configure default configuration",
+									exception);
+						}
+						play.Logger.error(
+								"Can't configure logback with specified file {} - Keep default configuration",
+								logbackConfFilename, exception);
+					}
+
+				} else {
+					play.Logger.warn(
+							"Can't read logback configuration conf/logback.developer.xml - Keeping default configuration.");
+				}
+
 			}
 			Globals.taskManager.init();
 			Globals.taskManager.execute();

--- a/app/Global.java
+++ b/app/Global.java
@@ -17,20 +17,13 @@
  */
 import static play.mvc.Results.notFound;
 
-import java.io.File;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.slf4j.LoggerFactory;
-
-import ch.qos.logback.classic.BasicConfigurator;
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.joran.JoranConfigurator;
-import ch.qos.logback.classic.util.ContextInitializer;
-import ch.qos.logback.core.joran.spi.JoranException;
+import helper.DevLoggerContext;
 import helper.oai.OaiDispatcher;
 import models.Globals;
 import play.Application;
@@ -63,53 +56,9 @@ public class Global extends GlobalSettings {
 				Globals.search.init(Globals.namespaces);
 			} else {
 				// play Framework läuft im Test- oder Entwicklungsmodus
-				// Logger-Konfiguration für Entwicklung laden
-				// Quelle hier:
-				// http://stackoverflow.com/questions/14288623/logback-externalization
-
-				String logbackConfFilename = "conf/logback.developer.xml";
-				File logbackConfigurationFile = null;
-				try {
-					logbackConfigurationFile =
-							Play.application().getFile(logbackConfFilename);
-				} catch (Exception exception) {
-					play.Logger.error("Can't read resource {} !", logbackConfFilename,
-							exception);
-				}
-
-				if (logbackConfigurationFile.exists()) {
-
-					play.Logger.info(
-							"Found logback configuration {} - Overriding default configuration.",
-							logbackConfFilename);
-					JoranConfigurator configurator = new JoranConfigurator();
-					LoggerContext loggerContext =
-							(LoggerContext) LoggerFactory.getILoggerFactory();
-					loggerContext.reset();
-					configurator.setContext(loggerContext);
-					try {
-						configurator.doConfigure(logbackConfigurationFile);
-						play.Logger.info(
-								"Default configuration overridden by logback configuration {}.",
-								logbackConfFilename);
-					} catch (Exception exception) {
-						try {
-							new ContextInitializer(loggerContext).autoConfig();
-						} catch (JoranException e) {
-							BasicConfigurator.configureDefaultContext();
-							play.Logger.error("Can't configure default configuration",
-									exception);
-						}
-						play.Logger.error(
-								"Can't configure logback with specified file {} - Keep default configuration",
-								logbackConfFilename, exception);
-					}
-
-				} else {
-					play.Logger.warn(
-							"Can't read logback configuration conf/logback.developer.xml - Keeping default configuration.");
-				}
-
+				// Logger-Konfiguration für Entwickler/innen laden
+				DevLoggerContext.doConfigure(Play.application().configuration()
+						.getString("logger.config.developer"));
 			}
 			Globals.taskManager.init();
 			Globals.taskManager.execute();

--- a/app/helper/DevLoggerContext.java
+++ b/app/helper/DevLoggerContext.java
@@ -1,0 +1,54 @@
+package helper;
+
+import java.io.File;
+
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import play.Play;
+
+/**
+ * @author I. Kuss
+ *         <ul>
+ *         <li>Developer Logger Context - konfiguriert einen Logger für
+ *         Entwickler/innen</li>
+ *         <li>benutzt JoranConfigurator, um die Logback Konfiguration zu
+ *         überschreiben</li>
+ *         <li>die Konfiguration selber muss als externe Datei (z.B.
+ *         logback.xml) übergeben werden</li>
+ *         </ul>
+ *
+ */
+public class DevLoggerContext {
+	// Quelle hier:
+	// http://stackoverflow.com/questions/14288623/logback-externalization
+
+	/**
+	 * @param logbackConfFilename - Dateiname der logback.xml mit vorangestelltem
+	 *          relativem Pfad, also z.B. "conf/logback.xml"
+	 */
+	public static void doConfigure(String logbackConfFilename) {
+		File logbackConfigurationFile = null;
+		try {
+			logbackConfigurationFile =
+					Play.application().getFile(logbackConfFilename);
+			play.Logger.info("logback configuration {} wird geladen.",
+					logbackConfFilename);
+			JoranConfigurator configurator = new JoranConfigurator();
+			LoggerContext loggerContext =
+					(LoggerContext) LoggerFactory.getILoggerFactory();
+			loggerContext.reset();
+			configurator.setContext(loggerContext);
+			configurator.doConfigure(logbackConfigurationFile);
+			play.Logger.info(
+					"Default configuration overridden by logback configuration {}.",
+					logbackConfFilename);
+		} catch (Exception exception) {
+			throw new RuntimeException("Can't configure logback with specified file "
+					+ logbackConfFilename + " - Keeping default configuration",
+					exception);
+		}
+	}
+
+}

--- a/conf/logback.developer.xml
+++ b/conf/logback.developer.xml
@@ -1,0 +1,88 @@
+<!--
+  ~ Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+  -->
+<!-- Logback configuration for developers by I. Kuss (hbz)  -->
+<!--   macht kürzere Log-Zeilen als Standard-Logging -->
+<!--   zeigt Klasse, Methode, Zeile anstatt Logger und Thread -->
+<configuration>
+    
+  <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
+
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+     <file>${application.home}/logs/application.log</file>
+     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+       <!-- Daily rollover with compression -->
+       <fileNamePattern>${application.home}/logs/application-log-%d{yyyy-MM-dd}.gz</fileNamePattern>
+       <!-- keep 366 days worth of history -->
+       <maxHistory>9999</maxHistory>
+     </rollingPolicy>
+     <encoder>
+       <pattern>%date [%level] %class{36}.%M Z.%L - %message%n%xException</pattern>
+     </encoder>
+  </appender>
+
+  <appender name="FILE-WEBGATHERER" class="ch.qos.logback.core.rolling.RollingFileAppender">
+     <file>${application.home}/logs/webgatherer.log</file>
+     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+       <!-- Daily rollover with compression -->
+       <fileNamePattern>${application.home}/logs/webgatherer-log-%d{yyyy-MM-dd}.gz</fileNamePattern>
+       <!-- keep 366 days worth of history -->
+       <maxHistory>9999</maxHistory>
+     </rollingPolicy>
+     <encoder>
+       <pattern>%date [%level] %class{36}.%M Z.%L - %message%n%xException</pattern>
+     </encoder>
+  </appender>
+
+  <appender name="FILE-ADDURN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+     <file>${application.home}/logs/addurn.log</file>
+     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+       <!-- Daily rollover with compression -->
+       <fileNamePattern>${application.home}/logs/addurn-log-%d{yyyy-MM-dd}</fileNamePattern>
+       <!-- keep 366 days worth of history -->
+       <maxHistory>9999</maxHistory>
+     </rollingPolicy>
+     <encoder>
+       <pattern>%date [%level] %class{36}.%M Z.%L - %message%n%xException</pattern>
+     </encoder>
+  </appender>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%coloredLevel %class{36}.%M Z.%L - %message%n%xException{10}</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="FILE" />
+  </appender>
+
+  <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="STDOUT" />
+  </appender>
+
+  <!--logger name="play" level="INFO" /-->
+  <logger name="application" level="DEBUG">
+    <appender-ref ref="FILE" />
+  </logger>
+  <logger name="webgatherer" level="DEBUG" additivity="false">
+    <appender-ref ref="FILE-WEBGATHERER" />
+  </logger>
+  <logger name="addurn" level="DEBUG" additivity="false">
+    <appender-ref ref="FILE-ADDURN" />
+  </logger>
+  
+  <!-- Off these ones as they are annoying, and anyway we manage configuration ourself -->
+  <logger name="com.avaje.ebean.config.PropertyMapLoader" level="OFF" />
+  <logger name="com.avaje.ebeaninternal.server.core.XmlConfigLoader" level="OFF" />
+  <logger name="com.avaje.ebeaninternal.server.lib.BackgroundThread" level="OFF" />
+  <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
+
+  <root level="WARN">
+    <appender-ref ref="FILE" />
+    <appender-ref ref="ASYNCFILE" />
+    <appender-ref ref="ASYNCSTDOUT" />
+  </root>
+  
+</configuration>
+


### PR DESCRIPTION
- wird die Play Anwendung im Entwicklungsmodus gestartet, wird eine andere Logback Konfiguration geladen
- benutzt JoranConfigurator, um die Konfig Datei zu laden
- mit beispielhafter Konfig-Datei "logback.developer.xml"
  - macht kürzere Meldungen
  - Angabe von Klasse und Zeilennummer im Log
  - die hier mitgelieferte Konfig-Datei kann individuell verbessert oder verfeinert werden
    (z.B. unterschiedl. Log-Level in versch. Log-Dateien o.ä., je nach Belieben).
