### PR TITLE
add Umzugsservice Basisimplementation

### DIFF
--- a/app/actions/Create.java
+++ b/app/actions/Create.java
@@ -17,14 +17,15 @@
 package actions;
 
 import static archive.fedora.Vocabulary.TYPE_OBJECT;
-import helper.HttpArchiveException;
-import helper.oai.OaiDispatcher;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 
+import helper.HttpArchiveException;
+import helper.mail.WebgatherExceptionMail;
+import helper.oai.OaiDispatcher;
 import models.Gatherconf;
 import models.Globals;
 import models.Node;
@@ -50,6 +51,9 @@ public class Create extends RegalAction {
 		}
 
 	}
+
+	// @Inject
+	// MailerClient mailerClient;
 
 	/**
 	 * @param node
@@ -231,6 +235,7 @@ public class Create extends RegalAction {
 	 * @return a new version pointing to a heritrix crawl
 	 */
 	public Node createWebpageVersion(Node n) {
+		Gatherconf conf = null;
 		try {
 			if (Globals.heritrix.isBusy()) {
 				throw new WebgathererTooBusyException(403,
@@ -241,7 +246,7 @@ public class Create extends RegalAction {
 						+ " is not supported. Operation works only on regalType:\"webpage\"");
 			}
 			WebgatherLogger.debug("Create webpageVersion " + n.getPid());
-			Gatherconf conf = Gatherconf.create(n.getConf());
+			conf = Gatherconf.create(n.getConf());
 			WebgatherLogger.debug("Create webpageVersi " + conf.toString());
 			// execute heritrix job
 			conf.setName(n.getPid());
@@ -295,7 +300,10 @@ public class Create extends RegalAction {
 
 			return webpageVersion;
 		} catch (Exception e) {
+			// verschickt E-Mail "Crawlen der Website fehlgeschlagen..."
+			WebgatherExceptionMail.sendMail(n.getPid(), conf.getUrl());
 			throw new RuntimeException(e);
 		}
 	}
-}
+
+} /* END of Class Create */

--- a/app/helper/Mail.java
+++ b/app/helper/Mail.java
@@ -1,0 +1,125 @@
+package helper;
+
+import java.util.*;
+import javax.mail.*;
+import javax.mail.internet.*;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import play.Logger;
+import play.Play;
+
+/**
+ * @author I. Kuss
+ * @description Class for sending an E-Mail with javax.mail
+ *
+ */
+public class Mail {
+
+	private String to;
+	private String from;
+	private String message;
+	private String subject;
+	private String smtpServ;
+	private String host;
+
+	/**
+	 * Konstruktor für die Klasse Mail. Legt SMTP-Server und aktuellen Hostnamen
+	 * fest
+	 */
+	public Mail() {
+		this.smtpServ = Play.application().configuration().getString("javax.mail.smtpServ");
+		try {
+			this.host = InetAddress.getLocalHost().getHostName();
+		} catch (UnknownHostException e) {
+			play.Logger.warn("Hostname nicht bekannt: {}", e);
+			play.Logger.info("Nehme als Default-Hostnamen \"localhost\"");
+			this.host = "localhost";
+
+		}
+	}
+
+	/**
+	 * verschickt eine Email mit javax.mail. Absender, Empfänger, Betreffzeile
+	 * und die eigentliche Nachricht (String) müssen vorher als Instanzvariablen
+	 * gesetzt worden sein.
+	 * 
+	 * @return int (0 = OK, -1 = ERROR)
+	 */
+	public int sendMail() {
+		try {
+
+			Properties props = System.getProperties();
+			props.put("mail.transport.protocol", "smtp");
+			props.put("mail.smtp.starttls.enable", "true");
+			props.put("mail.smtp.host", smtpServ);
+			props.put("mail.smtp.auth", "true");
+			Authenticator auth = new SMTPAuthenticator();
+			Session session = Session.getInstance(props, auth);
+			// -- Create a new message --
+			Message msg = new MimeMessage(session);
+			// -- Set the FROM and TO fields --
+			msg.setFrom(new InternetAddress(from + "@" + host));
+			msg.setRecipients(Message.RecipientType.TO, InternetAddress.parse(to, false));
+			msg.setSubject(subject);
+			msg.setText(message);
+			// -- Set some other header information --
+			// msg.setHeader("Content-Type", "text/pain");
+			msg.setSentDate(new Date());
+			// -- Send the message --
+			Transport.send(msg);
+			play.Logger.info("Message sent to" + to + " OK.");
+			return 0;
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			play.Logger.error("Exception: " + ex);
+			return -1;
+		}
+	}
+
+	private class SMTPAuthenticator extends javax.mail.Authenticator {
+		@Override
+		public PasswordAuthentication getPasswordAuthentication() {
+			// (sender's email id)
+			String username = Play.application().configuration().getString("javax.mail.user");
+			String password = Play.application().configuration().getString("javax.mail.password");
+			return new PasswordAuthentication(username, password);
+		}
+	}
+
+	public String getTo() {
+		return to;
+	}
+
+	public void setTo(String to) {
+		this.to = to;
+	}
+
+	public String getFrom() {
+		return from;
+	}
+
+	public void setFrom(String from) {
+		this.from = from;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+
+	public void setMessage(String message) {
+		this.message = message;
+	}
+
+	public String getSubject() {
+		return subject;
+	}
+
+	public void setSubject(String subject) {
+		this.subject = subject;
+	}
+
+	public String getSmtpServ() {
+		return smtpServ;
+	}
+
+}

--- a/app/helper/mail/Mail.java
+++ b/app/helper/mail/Mail.java
@@ -1,0 +1,125 @@
+package helper.mail;
+
+import java.util.*;
+import javax.mail.*;
+import javax.mail.internet.*;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import play.Logger;
+import play.Play;
+
+/**
+ * @author I. Kuss
+ * @description Class for sending an E-Mail with javax.mail
+ *
+ */
+public class Mail {
+
+	private String to;
+	private String from;
+	private String message;
+	private String subject;
+	private String smtpServ;
+	private String host;
+
+	/**
+	 * Konstruktor für die Klasse Mail. Legt SMTP-Server und aktuellen Hostnamen
+	 * fest
+	 */
+	public Mail() {
+		this.smtpServ = Play.application().configuration().getString("javax.mail.smtpServ");
+		try {
+			this.host = InetAddress.getLocalHost().getHostName();
+		} catch (UnknownHostException e) {
+			play.Logger.warn("Hostname nicht bekannt: {}", e);
+			play.Logger.info("Nehme als Default-Hostnamen \"localhost\"");
+			this.host = "localhost";
+
+		}
+	}
+
+	/**
+	 * verschickt eine Email mit javax.mail. Absender, Empfänger, Betreffzeile
+	 * und die eigentliche Nachricht (String) müssen vorher als Instanzvariablen
+	 * gesetzt worden sein.
+	 * 
+	 * @return int (0 = OK, -1 = ERROR)
+	 */
+	public int sendMail() {
+		try {
+
+			Properties props = System.getProperties();
+			props.put("mail.transport.protocol", "smtp");
+			props.put("mail.smtp.starttls.enable", "true");
+			props.put("mail.smtp.host", smtpServ);
+			props.put("mail.smtp.auth", "true");
+			Authenticator auth = new SMTPAuthenticator();
+			Session session = Session.getInstance(props, auth);
+			// -- Create a new message --
+			Message msg = new MimeMessage(session);
+			// -- Set the FROM and TO fields --
+			msg.setFrom(new InternetAddress(from + "@" + host));
+			msg.setRecipients(Message.RecipientType.TO, InternetAddress.parse(to, false));
+			msg.setSubject(subject);
+			msg.setText(message);
+			// -- Set some other header information --
+			// msg.setHeader("Content-Type", "text/pain");
+			msg.setSentDate(new Date());
+			// -- Send the message --
+			Transport.send(msg);
+			play.Logger.info("Message sent to" + to + " OK.");
+			return 0;
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			play.Logger.error("Exception: " + ex);
+			return -1;
+		}
+	}
+
+	private class SMTPAuthenticator extends javax.mail.Authenticator {
+		@Override
+		public PasswordAuthentication getPasswordAuthentication() {
+			// (sender's email id)
+			String username = Play.application().configuration().getString("javax.mail.user");
+			String password = Play.application().configuration().getString("javax.mail.password");
+			return new PasswordAuthentication(username, password);
+		}
+	}
+
+	public String getTo() {
+		return to;
+	}
+
+	public void setTo(String to) {
+		this.to = to;
+	}
+
+	public String getFrom() {
+		return from;
+	}
+
+	public void setFrom(String from) {
+		this.from = from;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+
+	public void setMessage(String message) {
+		this.message = message;
+	}
+
+	public String getSubject() {
+		return subject;
+	}
+
+	public void setSubject(String subject) {
+		this.subject = subject;
+	}
+
+	public String getSmtpServ() {
+		return smtpServ;
+	}
+
+}

--- a/app/helper/mail/WebgatherExceptionMail.java
+++ b/app/helper/mail/WebgatherExceptionMail.java
@@ -1,0 +1,47 @@
+/**
+ * 
+ */
+package helper.mail;
+
+import play.Logger;
+import play.Play;
+
+/**
+ * @author I. Kuss
+ * @description die Methode sendMail() verschickt eine E-Mail, dass eine Website
+ *              nicht gecrawlt werden konnte
+ *
+ */
+public class WebgatherExceptionMail {
+
+	private static final Logger.ALogger WebgatherLogger =
+			Logger.of("webgatherer");
+
+	public static void sendMail(String pid, String url) {
+
+		WebgatherLogger.error("Website {} kann nicht gecrawlt werden !", pid);
+		// E-Mail erzeugen, dass Website nicht gecrawlt werden kann
+		Mail mail = new Mail();
+		mail.setTo(Play.application().configuration().getString("javax.mail.to"));
+		mail.setFrom(
+				Play.application().configuration().getString("javax.mail.from"));
+		String mailMsg = "Das Crawlen der Website " + pid + " ist fehlgeschlagen !";
+		if (url != null) {
+			mailMsg += "\nURL: " + url;
+		}
+		mail.setMessage(mailMsg);
+		mail.setSubject("ERROR crawling Webpage " + pid);
+
+		String to = mail.getTo();
+		int result = 0;
+		result = mail.sendMail();
+		if (result == 0) {
+			WebgatherLogger
+					.info(" Webgather Exception E-Mail erfolgreich verschickt an " + to);
+		} else {
+			WebgatherLogger
+					.error("E-Mail an " + to + " konnte nicht zugestellt werden !");
+		}
+	}
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,8 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" %"jackson-core" %"2.6.3",
   "com.fasterxml" %"jackson-module-json-org" %"0.9.1",
   "com.fasterxml.jackson.core" %"jackson-databind" %"2.6.3",
-  "com.fasterxml.jackson.dataformat" %"jackson-dataformat-xml" %"2.6.3"
+  "com.fasterxml.jackson.dataformat" %"jackson-dataformat-xml" %"2.6.3",
+  "javax.mail" % "mail" % "1.4.2"
 )
 
 val root = (project in file(".")).enablePlugins(PlayJava)

--- a/test/MailTest.java
+++ b/test/MailTest.java
@@ -1,0 +1,41 @@
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import base.BaseModelTest;
+import helper.mail.Mail;
+import play.Play;
+import static play.test.Helpers.fakeApplication;
+
+/**
+ * @author I. Kuss
+ *
+ *         <ul>
+ *         <li>Tests sending an E-Mail with javax.mail</li>
+ *         <li>Tests the class helper/Mail.java</li>
+ *         </ul>
+ * 
+ */
+public class MailTest extends BaseModelTest {
+
+	private Mail mail = null;
+
+	@Before
+	public void setUp() {
+		mail = new Mail();
+		mail.setTo(fakeApplication().configuration().getString("javax.mail.totest"));
+		mail.setFrom(fakeApplication().configuration().getString("javax.mail.from"));
+		String mailMsg = "This is a test message from the JUnitTest regal-api/test/MailTest.java";
+		mail.setMessage(mailMsg);
+		mail.setSubject("INFO Test message from regal-api/test/MailTest");
+	}
+
+	@Test
+	public final void testSendMail() {
+		// Test-E-Mail abschicken, Returnwert muss NULL sein
+		assertEquals(mail.sendMail(), (int) 0);
+	}
+
+}

--- a/test/MailTest.java
+++ b/test/MailTest.java
@@ -1,0 +1,41 @@
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import base.BaseModelTest;
+import helper.Mail;
+import play.Play;
+import static play.test.Helpers.fakeApplication;
+
+/**
+ * @author I. Kuss
+ *
+ *         <ul>
+ *         <li>Tests sending an E-Mail with javax.mail</li>
+ *         <li>Tests the class helper/Mail.java</li>
+ *         </ul>
+ * 
+ */
+public class MailTest extends BaseModelTest {
+
+	private Mail mail = null;
+
+	@Before
+	public void setUp() {
+		mail = new Mail();
+		mail.setTo(fakeApplication().configuration().getString("javax.mail.totest"));
+		mail.setFrom(fakeApplication().configuration().getString("javax.mail.from"));
+		String mailMsg = "This is a test message from the JUnitTest regal-api/test/MailTest.java";
+		mail.setMessage(mailMsg);
+		mail.setSubject("INFO Test message from regal-api/test/MailTest");
+	}
+
+	@Test
+	public final void testSendMail() {
+		// Test-E-Mail abschicken, Returnwert muss NULL sein
+		assertEquals(mail.sendMail(), (int) 0);
+	}
+
+}


### PR DESCRIPTION
```
Folgendes geht jetzt:
 * wenn das Crawlen (=Anstarten des Crawls) einer Website scheitert, wird eine entsprechende Meldung ins webgatherer.log ausgegeben.
 * außerdem wird eine E-Mail verschickt. Die E-Mail enthält ID (edoweb:...) des Objekts und die URL, die gecrawlt werden sollte. Betreffszeile der E-Mail: "ERROR crawling Webpage ..."
 * E-Mail Empfänger sowie Informationen zum sendenden E-Mail-Account (SMTP-Server etc.) müssen in der application.conf in einem Abschnitt "Javax-Mail" (Variablennamen javax.mail.*) hinterlegt sein, damit der E-Mail Versand klappt.
```
