### PR TITLE
specify application specific location for cache file

### DIFF
--- a/conf/ehcache.xml
+++ b/conf/ehcache.xml
@@ -1,5 +1,5 @@
 <ehcache>
-	<diskStore path="java.io.tmpdir" />
+	<diskStore path="java.io.tmpdir/regal-api.cache" />
 	<defaultCache maxBytesLocalHeap="2G" eternal="false"
 		timeToIdleSeconds="90000" timeToLiveSeconds="0" maxBytesLocalDisk="10G"
 		diskExpiryThreadIntervalSeconds="120" memoryStoreEvictionPolicy="LFU">


### PR DESCRIPTION
- should prevent conflicts with other play apps who want
to use /tmp/play.data as well