### PR TITLE
Dreifach-Logging abgestellt

### DIFF
--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -60,7 +60,7 @@
   </appender>
 
   <!--logger name="play" level="INFO" /-->
-  <logger name="application" level="DEBUG">
+  <logger name="application" level="DEBUG" additivity="false">
     <appender-ref ref="FILE" />
   </logger>
   <logger name="webgatherer" level="DEBUG" additivity="false">
@@ -78,8 +78,8 @@
 
   <root level="WARN">
     <appender-ref ref="FILE" />
-    <appender-ref ref="ASYNCFILE" />
-    <appender-ref ref="ASYNCSTDOUT" />
+    <!--appender-ref ref="ASYNCFILE" /-->
+    <!--appender-ref ref="ASYNCSTDOUT" /-->
   </root>
   
 </configuration>


### PR DESCRIPTION
Dreifach-Logging abgestellt.
Zwei Änderungen in logback.xml.

    "additivity" fehlte in logger
    <root> hatte zu viele appender

Auf edoweb-test aktiviert und getestet (OK).