### PR TITLE
http GET authorisation

### DIFF
--- a/app/actions/BasicAuthAction.java
+++ b/app/actions/BasicAuthAction.java
@@ -42,9 +42,13 @@ public class BasicAuthAction extends Action<BasicAuth> {
 	public F.Promise<Result> call(Http.Context context) throws Throwable {
 
 		String authHeader = context.request().getHeader(AUTHORIZATION);
-
 		if (authHeader == null) {
-			return unauthorized(context);
+			if (context.request().method().equals("GET")) {
+				context.args.put("role", "edoweb-anonymous");
+				return delegate.call(context);
+			} else {
+				return unauthorized(context);
+			}
 		}
 
 		String auth = authHeader.substring(6);


### PR DESCRIPTION
- if no authorisation header is passed
set authorisation to edoweb-anonymous by default
- only for http GET for all other http verbs an authorisation
header is mandatory