### PR TITLE
Edozwo 713

### DIFF
--- a/app/actions/Create.java
+++ b/app/actions/Create.java
@@ -25,6 +25,7 @@ import java.util.List;
 import helper.HttpArchiveException;
 import helper.mail.WebgatherExceptionMail;
 import helper.oai.OaiDispatcher;
+import helper.WpullCrawl;
 import models.Gatherconf;
 import models.Globals;
 import models.Node;
@@ -235,41 +236,60 @@ public class Create extends RegalAction {
 	 */
 	public Node createWebpageVersion(Node n) {
 		Gatherconf conf = null;
+		File crawlDir = null;
+		String localpath = null;
 		try {
-			if (Globals.heritrix.isBusy()) {
-				throw new WebgathererTooBusyException(403,
-						"Webgatherer is too busy! Please try again later.");
-			}
 			if (!"webpage".equals(n.getContentType())) {
 				throw new HttpArchiveException(400, n.getContentType()
 						+ " is not supported. Operation works only on regalType:\"webpage\"");
 			}
-			WebgatherLogger.debug("Create webpageVersion " + n.getPid());
+			WebgatherLogger.debug("Create webpageVersion for name " + n.getPid());
 			conf = Gatherconf.create(n.getConf());
-			WebgatherLogger.debug("Create webpageVersi " + conf.toString());
-			// execute heritrix job
+			WebgatherLogger
+					.debug("Create webpageVersion with conf " + conf.toString());
 			conf.setName(n.getPid());
-			if (!Globals.heritrix.jobExists(conf.getName())) {
-				Globals.heritrix.createJob(conf);
+			if (conf.getCrawlerSelection()
+					.equals(Gatherconf.CrawlerSelection.heritrix)) {
+				if (Globals.heritrix.isBusy()) {
+					throw new WebgathererTooBusyException(403,
+							"Webgatherer is too busy! Please try again later.");
+				}
+				if (!Globals.heritrix.jobExists(conf.getName())) {
+					Globals.heritrix.createJob(conf);
+				}
+				boolean success = Globals.heritrix.teardown(conf.getName());
+				WebgatherLogger.debug("Teardown " + conf.getName() + " " + success);
+
+				Globals.heritrix.launch(conf.getName());
+				WebgatherLogger.debug("Launched " + conf.getName());
+				Thread.currentThread().sleep(10000);
+
+				Globals.heritrix.unpause(conf.getName());
+				WebgatherLogger.debug("Unpaused " + conf.getName());
+				Thread.currentThread().sleep(10000);
+
+				crawlDir = Globals.heritrix.getCurrentCrawlDir(conf.getName());
+				String warcPath = Globals.heritrix.findLatestWarc(crawlDir);
+				String uriPath = Globals.heritrix.getUriPath(warcPath);
+
+				localpath = Globals.heritrixData + "/heritrix-data" + "/" + uriPath;
+				WebgatherLogger.debug("Path to WARC " + localpath);
+			} else if (conf.getCrawlerSelection()
+					.equals(Gatherconf.CrawlerSelection.wpull)) {
+				WpullCrawl wpullCrawl = new WpullCrawl(conf);
+				wpullCrawl.createJob();
+				wpullCrawl.startJob();
+				crawlDir = wpullCrawl.getCrawlDir();
+				localpath = wpullCrawl.getLocalpath();
+				if (wpullCrawl.getExitState() != 0) {
+					throw new RuntimeException("Crawl job returns with exit state "
+							+ wpullCrawl.getExitState() + "!");
+				}
+				WebgatherLogger.debug("Path to WARC " + localpath);
+			} else {
+				throw new RuntimeException(
+						"Unknown crawler selection " + conf.getCrawlerSelection() + "!");
 			}
-			boolean success = Globals.heritrix.teardown(conf.getName());
-			WebgatherLogger.debug("Teardown " + conf.getName() + " " + success);
-
-			Globals.heritrix.launch(conf.getName());
-			WebgatherLogger.debug("Launched " + conf.getName());
-			Thread.currentThread().sleep(10000);
-
-			Globals.heritrix.unpause(conf.getName());
-			WebgatherLogger.debug("Unpaused " + conf.getName());
-			Thread.currentThread().sleep(10000);
-
-			File crawlDir = Globals.heritrix.getCurrentCrawlDir(conf.getName());
-			String warcPath = Globals.heritrix.findLatestWarc(crawlDir);
-			String uriPath = Globals.heritrix.getUriPath(warcPath);
-
-			String localpath =
-					Globals.heritrixData + "/heritrix-data" + "/" + uriPath;
-			WebgatherLogger.debug("Path to WARC " + localpath);
 
 			// create fedora object with unmanaged content pointing to
 			// the respective warc container
@@ -303,7 +323,6 @@ public class Create extends RegalAction {
 
 			return webpageVersion;
 		} catch (Exception e) {
-			// verschickt E-Mail "Crawlen der Website fehlgeschlagen..."
 			// WebgatherExceptionMail.sendMail(n.getPid(), conf.getUrl());
 			WebgatherLogger.warn("Crawl of Webpage " + n.getPid() + ","
 					+ conf.getUrl() + " has failed !\n\tReason: " + e.getMessage());

--- a/app/actions/Create.java
+++ b/app/actions/Create.java
@@ -285,7 +285,7 @@ public class Create extends RegalAction {
 					throw new RuntimeException("Crawl job returns with exit state "
 							+ wpullCrawl.getExitState() + "!");
 				}
-				WebgatherLogger.debug("Path to WARC " + localpath);
+				WebgatherLogger.debug("Path to WARC " + crawlDir.getAbsolutePath());
 			} else {
 				throw new RuntimeException(
 						"Unknown crawler selection " + conf.getCrawlerSelection() + "!");
@@ -306,7 +306,9 @@ public class Create extends RegalAction {
 			new Modify().updateLobidifyAndEnrichMetadata(webpageVersion,
 					"<" + webpageVersion.getPid()
 							+ "> <http://purl.org/dc/terms/title> \"" + label + "\" .");
-			webpageVersion.setLocalData(localpath);
+			if (localpath != null) {
+				webpageVersion.setLocalData(localpath);
+			}
 			webpageVersion.setMimeType("application/warc");
 			webpageVersion.setFileLabel(label);
 			webpageVersion.setAccessScheme(n.getAccessScheme());

--- a/app/helper/WpullCrawl.java
+++ b/app/helper/WpullCrawl.java
@@ -45,6 +45,8 @@ public class WpullCrawl {
 
 	final String jobDir =
 			Play.application().configuration().getString("regal-api.wpull.jobDir");
+	final String crawler =
+			Play.application().configuration().getString("regal-api.wpull.crawler");
 
 	private static final Logger.ALogger WebgatherLogger =
 			Logger.of("webgatherer");
@@ -104,7 +106,7 @@ public class WpullCrawl {
 			String urlRaw = conf.getUrl().replaceAll("^http://", "")
 					.replaceAll("^https://", "").replaceAll("/$", "");
 			String warcFilename = "WEB-" + urlRaw + "-" + date;
-			String executeCommand = "wpull3 " + conf.getUrl();
+			String executeCommand = crawler + " " + conf.getUrl();
 			ArrayList<String> domains = conf.getDomains();
 			if (domains.size() > 0) {
 				executeCommand += " --span-hosts";

--- a/app/helper/WpullCrawl.java
+++ b/app/helper/WpullCrawl.java
@@ -116,11 +116,11 @@ public class WpullCrawl {
 			executeCommand += " --recursive";
 			ArrayList<String> urlsExcluded = conf.getUrlsExcluded();
 			if (urlsExcluded.size() > 0) {
-				executeCommand += " --reject-regex=\".*" + urlsExcluded.get(0);
-				for (int i = 1; i < domains.size(); i++) {
+				executeCommand += " --reject-regex=.*" + urlsExcluded.get(0);
+				for (int i = 1; i < urlsExcluded.size(); i++) {
 					executeCommand += "|" + urlsExcluded.get(i);
 				}
-				executeCommand += ".*\"";
+				executeCommand += ".*";
 			}
 			executeCommand += " --link-extractors=javascript,html,css";
 			executeCommand += " --warc-file=" + warcFilename;

--- a/app/helper/WpullCrawl.java
+++ b/app/helper/WpullCrawl.java
@@ -135,8 +135,10 @@ public class WpullCrawl {
 			WebgatherLogger.info("Logfile = " + crawlDir.toString() + "/crawl.log");
 			String[] execArr = executeCommand.split(" ");
 			ProcessBuilder pb = new ProcessBuilder(execArr);
+			assert crawlDir.isDirectory();
 			pb.directory(crawlDir);
 			File log = new File(crawlDir.toString() + "/crawl.log");
+			log.createNewFile();
 			pb.redirectErrorStream(true);
 			pb.redirectOutput(ProcessBuilder.Redirect.appendTo(log));
 			Process proc = pb.start();

--- a/app/helper/WpullCrawl.java
+++ b/app/helper/WpullCrawl.java
@@ -17,6 +17,7 @@
 package helper;
 
 import models.Gatherconf;
+import models.Globals;
 import play.Logger;
 import play.Play;
 
@@ -36,11 +37,8 @@ public class WpullCrawl {
 
 	private Gatherconf conf = null;
 	private String date = null;
+	private String datetime = null;
 	private File crawlDir = null;
-	/*
-	 * variable localhost remains zero as wpull has no administrative surface on
-	 * localhost (in contrast to heritrix)
-	 */
 	private String localpath = null;
 	private int exitState = 0;
 	private String msg = null;
@@ -82,7 +80,7 @@ public class WpullCrawl {
 				throw new RuntimeException("The configuration has no name !");
 			}
 			date = new SimpleDateFormat("yyyyMMdd").format(new java.util.Date());
-			String datetime =
+			datetime =
 					date + new SimpleDateFormat("HHmmss").format(new java.util.Date());
 			crawlDir = new File(jobDir + "/" + conf.getName() + "/" + datetime);
 			if (!crawlDir.exists()) {
@@ -133,6 +131,8 @@ public class WpullCrawl {
 					" --no-host-directories --convert-links --page-requisites --no-parent";
 			executeCommand += " --database=" + warcFilename + ".db";
 			executeCommand += " --no-check-certificate";
+			WebgatherLogger.info("Executing command " + executeCommand);
+			WebgatherLogger.info("Logfile = " + crawlDir.toString() + "/crawl.log");
 			String[] execArr = executeCommand.split(" ");
 			ProcessBuilder pb = new ProcessBuilder(execArr);
 			pb.directory(crawlDir);
@@ -143,6 +143,13 @@ public class WpullCrawl {
 			assert pb.redirectInput() == ProcessBuilder.Redirect.PIPE;
 			assert pb.redirectOutput().file() == log;
 			assert proc.getInputStream().read() == -1;
+			/*
+			 * den Pfad zum WARC unter Globals.heritrixData zu hängen ist eigentlich
+			 * Blödsinn, aber ohne localpath wird im Frontend kein Link zu Openwayback
+			 * erzeugt (warum nicht ?)
+			 */
+			localpath = Globals.heritrixData + "/wpull-data" + "/" + conf.getName()
+					+ "/" + datetime + "/" + warcFilename + ".warc.gz";
 			// exitState = proc.waitFor(); // don't wait
 		} catch (IOException ioe) {
 			WebgatherLogger.error(ioe.toString());

--- a/app/helper/WpullCrawl.java
+++ b/app/helper/WpullCrawl.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2014 hbz NRW (http://www.hbz-nrw.de/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package helper;
+
+import models.Gatherconf;
+import play.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.ProcessBuilder;
+import java.util.ArrayList;
+
+/**
+ * a class to implement a wpull crawl
+ * 
+ * @author Ingolf Kuss
+ *
+ */
+public class WpullCrawl {
+
+	private Gatherconf conf = null;
+	private File crawlDir = null;
+	private String localpath = null;
+	private int exitState = 0;
+
+	private static final Logger.ALogger WebgatherLogger =
+			Logger.of("webgatherer");
+
+	public File getCrawlDir() {
+		return crawlDir;
+	}
+
+	public String getLocalpath() {
+		return localpath;
+	}
+
+	public int getExitState() {
+		return exitState;
+	}
+
+	/**
+	 * a constructor of a wpull crawl
+	 * 
+	 * @param conf the crawler configuration for the website
+	 */
+	public WpullCrawl(Gatherconf conf) {
+		this.conf = conf;
+	}
+
+	/**
+	 * creates a new wpull crawler job
+	 */
+	public void createJob() {
+		// create subdirectory in wpull-data/
+		// crawlDir = ...
+	}
+
+	/**
+	 * starts crawling with wpull
+	 */
+	public void startJob() {
+		try {
+			// localpath = ...
+			String urlRaw = conf.getUrl().replaceAll("http://", "")
+					.replaceAll("https://", "").replaceAll("/$", "");
+			// date = ...
+			// String warcFilename = ...
+			String executeCommand = "wpull3 " + conf.getUrl();
+			ArrayList<String> domains = conf.getDomains();
+			// loop over domains
+			executeCommand +=
+					" --span-hosts --domains=$url_raw,www.bernkastel.de,www.rlpdirekt.de --recursive";
+			ArrayList<String> urlsExcluded = conf.getUrlsExcluded();
+			// loop over urlsExcluded
+			executeCommand +=
+					" --reject-regex=\".*Veranstaltungskalender|Bürgerservice.*\"";
+			executeCommand += " --link-extractors=javascript,html,css";
+			executeCommand += " --warc-file=WEB-" + urlRaw + "-${datum}"; // replace
+																																		// by
+																																		// warcFilename
+			executeCommand +=
+					" --user-agent \"InconspiciousWebBrowser/1.0\" --no-robots";
+			executeCommand += " --escaped-fragment --strip-session-id";
+			executeCommand +=
+					" --no-host-directories --convert-links --page-requisites --no-parent";
+			executeCommand += " --database WEB-${url_raw}-${datum}.db";
+			executeCommand += " --no-check-certificate";
+			String[] execArr = executeCommand.split(" ");
+			ProcessBuilder pb = new ProcessBuilder(execArr);
+			pb.directory(crawlDir);
+			File log = new File(crawlDir.toString() + "/crawl.log");
+			pb.redirectErrorStream(true);
+			pb.redirectOutput(ProcessBuilder.Redirect.appendTo(log));
+			Process proc = pb.start();
+			assert pb.redirectInput() == ProcessBuilder.Redirect.PIPE;
+			assert pb.redirectOutput().file() == log;
+			assert proc.getInputStream().read() == -1;
+			// exitState = proc.waitFor(); // don't wait
+		} catch (IOException ioe) {
+			WebgatherLogger.error(ioe.toString());
+			throw new RuntimeException("wpull crawl not successfully started!", ioe);
+		}
+	}
+
+}

--- a/conf/logback.developer.xml
+++ b/conf/logback.developer.xml
@@ -65,7 +65,7 @@
   <logger name="application" level="INFO">
     <appender-ref ref="FILE" />
   </logger>
-  <logger name="webgatherer" level="INFO" additivity="false">
+  <logger name="webgatherer" level="DEBUG" additivity="false">
     <appender-ref ref="FILE-WEBGATHERER" />
   </logger>
   <logger name="addurn" level="INFO" additivity="false">


### PR DESCRIPTION
@jschnasse 
Bitte reviewen. Noch nicht commiten ! (siehe dazu nachfolgenden Kommentar von mir !)
Auf edoweb-test läuft es.
Z.B. https://edoweb-test.hbz-nrw.de/resource/edoweb%3A5950303
In den Crawler Settings kann die Auswahl "wpull" getroffen werden. Es können Pfade ausgeschlossen werden.
s. die Crawls in /opt/regal/wpull-data/edoweb:5950303
erzeugte Versions: https://edoweb-test.hbz-nrw.de/resource/edoweb:5950304, https://edoweb-test.hbz-nrw.de/resource/edoweb:5950305
Crawlen mit Heritrix geht natürlich auch noch, s. z.B. hier: /opt/regal/heritrix-data/edoweb:5950303/20171004161828 (keine Version angelegt, da Crawl über Heritrix Admin Ofl. erzeugt - sonst käme "Webgatherer too busy!").
