### PR TITLE
EDOZWO-734

### DIFF
--- a/app/helper/WpullCrawl.java
+++ b/app/helper/WpullCrawl.java
@@ -169,6 +169,7 @@ public class WpullCrawl {
 				" --no-host-directories --convert-links --page-requisites --no-parent");
 		sb.append(" --database=" + warcFilename + ".db");
 		sb.append(" --no-check-certificate --no-directories");
+		sb.append(" --delete-after");
 		return sb.toString();
 	}
 


### PR DESCRIPTION
 add parameter --delete-after to wpull
 - this deletes the dowloaded file structure and keeps only the WARC-archive, thus saves disk space

a trivial, one line change. Tested on localhost.