### PR TITLE
Webgatherer url encoding

### DIFF
--- a/app/helper/WebgatherUtils.java
+++ b/app/helper/WebgatherUtils.java
@@ -73,8 +73,8 @@ public class WebgatherUtils {
 	 * @return eine URL als Zeichenkette
 	 * @throws URISyntaxException eine Ausnahme, wenn die URL ungültig ist
 	 */
-	public static String validateURL(String url, boolean includeScheme,
-			boolean convertToPunycode) throws URISyntaxException {
+	public static String validateURL(String url, boolean convertToPunycode)
+			throws URISyntaxException {
 		if (url == null) {
 			return url;
 		}
@@ -105,8 +105,7 @@ public class WebgatherUtils {
 		String queryString =
 				uri.getRawQuery() != null ? "?" + uri.getRawQuery() : "";
 
-		urlRet = ((hasScheme && includeScheme) ? scheme : "") + authority + path
-				+ queryString;
+		urlRet = ((hasScheme) ? scheme : "") + authority + path + queryString;
 		// WebgatherLogger.debug("urlRet=" + urlRet);
 
 		// Convert path from unicode to ascii encoding
@@ -118,31 +117,9 @@ public class WebgatherUtils {
 		return urlRet;
 	}
 
-	/**
-	 * konvertiert eine URL nach ASCII und konvertiert nach Punycode. Das Schema
-	 * wird beibehalten (falls vorhanden).
-	 * 
-	 * @param url
-	 * @return die konvertierte URL
-	 * @throws URISyntaxException
-	 */
 	public static String convertUnicodeURLToAscii(String url)
 			throws URISyntaxException {
-		return convertUnicodeURLToAscii(url, true);
-	}
-
-	/**
-	 * konvertiert eine URL nach ASCII und konvertiert nach Punycode. Das Schema
-	 * kann wahlweise entfernt werden.
-	 * 
-	 * @param url
-	 * @param includeScheme
-	 * @return die konvertierte URL
-	 * @throws URISyntaxException
-	 */
-	public static String convertUnicodeURLToAscii(String url,
-			boolean includeScheme) throws URISyntaxException {
-		return validateURL(url, includeScheme, true);
+		return validateURL(url, true);
 	}
 
 	/**

--- a/app/helper/WebgatherUtils.java
+++ b/app/helper/WebgatherUtils.java
@@ -67,14 +67,10 @@ public class WebgatherUtils {
 	 * -in-java/
 	 * 
 	 * @param url ein Uniform Resource Locator als Zeichenkette
-	 * @param includeScheme das Schema wird mit zurückgegeben (J/N)
-	 * @param convertToPunycode falls wahr, wird nach Punycode konvertiert (und
-	 *          dann erst nach ASCII)
 	 * @return eine URL als Zeichenkette
 	 * @throws URISyntaxException eine Ausnahme, wenn die URL ungültig ist
 	 */
-	public static String validateURL(String url, boolean convertToPunycode)
-			throws URISyntaxException {
+	public static String validateURL(String url) throws URISyntaxException {
 		if (url == null) {
 			return url;
 		}
@@ -98,9 +94,9 @@ public class WebgatherUtils {
 				uri.getRawAuthority() != null ? uri.getRawAuthority() : "";
 		// WebgatherLogger.debug("authority=" + authority);
 		// Must convert domain to punycode separately from the path
-		if (convertToPunycode) {
-			authority = IDN.toASCII(authority);
-		}
+
+		authority = IDN.toASCII(authority);
+
 		String path = uri.getRawPath() != null ? uri.getRawPath() : "";
 		String queryString =
 				uri.getRawQuery() != null ? "?" + uri.getRawQuery() : "";
@@ -119,7 +115,7 @@ public class WebgatherUtils {
 
 	public static String convertUnicodeURLToAscii(String url)
 			throws URISyntaxException {
-		return validateURL(url, true);
+		return validateURL(url);
 	}
 
 	/**

--- a/app/helper/WebgatherUtils.java
+++ b/app/helper/WebgatherUtils.java
@@ -70,52 +70,17 @@ public class WebgatherUtils {
 	 * @return eine URL als Zeichenkette
 	 * @throws URISyntaxException eine Ausnahme, wenn die URL ungültig ist
 	 */
-	public static String validateURL(String url) throws URISyntaxException {
-		if (url == null) {
-			return url;
+	public static String convertUnicodeURLToAscii(String url) {
+		try {
+			URL u = new URL(url);
+			URI uri =
+					new URI(u.getProtocol(), u.getUserInfo(), IDN.toASCII(u.getHost()),
+							u.getPort(), u.getPath(), u.getQuery(), u.getRef());
+			String correctEncodedURL = uri.toASCIIString();
+			return correctEncodedURL;
+		} catch (Exception e) {
+			throw new RuntimeException(e);
 		}
-		String urlRet = url;
-		urlRet = url.trim();
-		// Handle international domains by detecting non-ascii and converting them
-		// to punycode
-		boolean isAscii = CharMatcher.ASCII.matchesAllOf(urlRet);
-		URI uri = new URI(urlRet);
-
-		boolean hasScheme = true;
-		// URI needs a scheme to work properly with authority parsing
-		if (uri.getScheme() == null) {
-			uri = new URI("http://" + urlRet);
-			hasScheme = false;
-		}
-
-		String scheme = uri.getScheme() != null ? uri.getScheme() + "://" : null;
-		/* authority includes domain and port */
-		String authority =
-				uri.getRawAuthority() != null ? uri.getRawAuthority() : "";
-		// WebgatherLogger.debug("authority=" + authority);
-		// Must convert domain to punycode separately from the path
-
-		authority = IDN.toASCII(authority);
-
-		String path = uri.getRawPath() != null ? uri.getRawPath() : "";
-		String queryString =
-				uri.getRawQuery() != null ? "?" + uri.getRawQuery() : "";
-
-		urlRet = ((hasScheme) ? scheme : "") + authority + path + queryString;
-		// WebgatherLogger.debug("urlRet=" + urlRet);
-
-		// Convert path from unicode to ascii encoding
-		if (!isAscii) {
-			urlRet = new URI(urlRet).toASCIIString();
-		}
-		WebgatherLogger.debug("url validated = " + urlRet);
-
-		return urlRet;
-	}
-
-	public static String convertUnicodeURLToAscii(String url)
-			throws URISyntaxException {
-		return validateURL(url);
 	}
 
 	/**

--- a/app/helper/WpullCrawl.java
+++ b/app/helper/WpullCrawl.java
@@ -103,7 +103,7 @@ public class WpullCrawl {
 					date + new SimpleDateFormat("HHmmss").format(new java.util.Date());
 			this.crawlDir = new File(jobDir + "/" + conf.getName() + "/" + datetime);
 			this.warcFilename = "WEB-" + host + "-" + date;
-		} catch (URISyntaxException e) {
+		} catch (Exception e) {
 			WebgatherLogger.error("Ungültige URL :" + conf.getUrl() + " !");
 			throw new RuntimeException(e);
 		}

--- a/test/helper/WebgatherUtilsTest.java
+++ b/test/helper/WebgatherUtilsTest.java
@@ -42,7 +42,7 @@ public class WebgatherUtilsTest {
 	}
 
 	private String encodeUrlOld(String url) throws URISyntaxException {
-		return WebgatherUtils.validateURL(url, true, true);
+		return WebgatherUtils.validateURL(url, true);
 	}
 
 	@Test

--- a/test/helper/WebgatherUtilsTest.java
+++ b/test/helper/WebgatherUtilsTest.java
@@ -1,0 +1,79 @@
+package helper;
+
+import java.io.InputStream;
+import java.net.IDN;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class WebgatherUtilsTest {
+	@Test
+	public void testUrlOld() {
+		try (InputStream in = Thread.currentThread().getContextClassLoader()
+				.getResourceAsStream("url-succeding-tests.json")) {
+			ObjectMapper mapper = new ObjectMapper();
+			JsonNode testdata = mapper.readValue(in, JsonNode.class).at("/tests");
+			for (JsonNode test : testdata) {
+				String url = test.at("/in").asText();
+				String expected = test.at("/out").asText();
+				String encodedUrl = "ERROR";
+
+				try {
+					encodedUrl = encodeUrlOld(url);
+				} catch (Exception e) {
+					System.err.println(e.getMessage());
+				}
+				if (!expected.equals(encodedUrl)) {
+					System.out.println("In:\t" + url);
+					System.out.println("Expect:\t" + expected);
+					System.out.println("Actual:\t" + encodedUrl);
+					System.out.println("");
+				}
+			}
+
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private String encodeUrlOld(String url) throws URISyntaxException {
+		return WebgatherUtils.validateURL(url, true, true);
+	}
+
+	@Test
+	public void testUrlNew() {
+		try (InputStream in = Thread.currentThread().getContextClassLoader()
+				.getResourceAsStream("url-succeding-tests.json")) {
+			ObjectMapper mapper = new ObjectMapper();
+			JsonNode testdata = mapper.readValue(in, JsonNode.class).at("/tests");
+			for (JsonNode test : testdata) {
+				String url = test.at("/in").asText();
+				String expected = test.at("/out").asText();
+				String encodedUrl = encodeUrlNew(url);
+
+				org.junit.Assert.assertTrue(expected.equals(encodedUrl));
+			}
+
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private String encodeUrlNew(String url) throws URISyntaxException {
+		try {
+			URL u = new URL(url);
+			URI uri =
+					new URI(u.getProtocol(), u.getUserInfo(), IDN.toASCII(u.getHost()),
+							u.getPort(), u.getPath(), u.getQuery(), u.getRef());
+			String correctEncodedURL = uri.toASCIIString();
+			return correctEncodedURL;
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/test/helper/WebgatherUtilsTest.java
+++ b/test/helper/WebgatherUtilsTest.java
@@ -42,7 +42,7 @@ public class WebgatherUtilsTest {
 	}
 
 	private String encodeUrlOld(String url) throws URISyntaxException {
-		return WebgatherUtils.validateURL(url);
+		return WebgatherUtils.convertUnicodeURLToAscii(url);
 	}
 
 	@Test

--- a/test/helper/WebgatherUtilsTest.java
+++ b/test/helper/WebgatherUtilsTest.java
@@ -42,7 +42,7 @@ public class WebgatherUtilsTest {
 	}
 
 	private String encodeUrlOld(String url) throws URISyntaxException {
-		return WebgatherUtils.validateURL(url, true);
+		return WebgatherUtils.validateURL(url);
 	}
 
 	@Test

--- a/test/resources/url-succeding-tests.json
+++ b/test/resources/url-succeding-tests.json
@@ -1,0 +1,243 @@
+{
+"tests":[ {
+  "in" : "file:///foo/bar.txt",
+  "out" : "file:///foo/bar.txt"
+}, {
+  "in" : "file:///home/me",
+  "out" : "file:///home/me"
+}, {
+  "in" : "file://localhost/",
+  "out" : "file://localhost/"
+}, {
+  "in" : "file://localhost/test",
+  "out" : "file://localhost/test"
+}, {
+  "in" : "file:///foo/bar.txt",
+  "out" : "file:///foo/bar.txt"
+}, {
+  "in" : "file:///home/me",
+  "out" : "file:///home/me"
+}, {
+  "in" : "file://localhost/",
+  "out" : "file://localhost/"
+}, {
+  "in" : "file://localhost/test",
+  "out" : "file://localhost/test"
+}, {
+  "in" : "http://GOO​⁠﻿goo.com/",
+  "out" : "http://googoo.com/"
+}, {
+  "in" : "http://www.foo。bar.com/",
+  "out" : "http://www.foo.bar.com/"
+}, {
+  "in" : "http://Ｇｏ.com/",
+  "out" : "http://go.com/"
+}, {
+  "in" : "http://你好你好/",
+  "out" : "http://xn--6qqa088eba/"
+}, {
+  "in" : "http://faß.de/",
+  "out" : "http://fass.de/"
+}, {
+  "in" : "http://βόλος.com/",
+  "out" : "http://xn--nxasmq6b.com/"
+}, {
+  "in" : "http://ශ්‍රී.com/",
+  "out" : "http://xn--10cl1a0b.com/"
+}, {
+  "in" : "http://نامه‌ای.com/",
+  "out" : "http://xn--mgba3gch31f.com/"
+}, {
+  "in" : "http://www.looĸout.net/",
+  "out" : "http://www.xn--looout-5bb.net/"
+}, {
+  "in" : "http://ᗯᗯᗯ.lookout.net/",
+  "out" : "http://xn--1qeaa.lookout.net/"
+}, {
+  "in" : "http://www.lookout.сом/",
+  "out" : "http://www.lookout.xn--l1adi/"
+}, {
+  "in" : "http://www.lookout‧net/",
+  "out" : "http://www.xn--lookoutnet-406e/"
+}, {
+  "in" : "http://www.looĸout.net/",
+  "out" : "http://www.xn--looout-5bb.net/"
+}, {
+  "in" : "http://Bücher.de/",
+  "out" : "http://xn--bcher-kva.de/"
+}, {
+  "in" : "http://look͏out.net/",
+  "out" : "http://lookout.net/"
+}, {
+  "in" : "http://192.168.0.1/",
+  "out" : "http://192.168.0.1/"
+}, {
+  "in" : "http://[::]/",
+  "out" : "http://[::]/"
+}, {
+  "in" : "http://[::1]/",
+  "out" : "http://[::1]/"
+}, {
+  "in" : "http://www.example.com/foo/..bar",
+  "out" : "http://www.example.com/foo/..bar"
+}, {
+  "in" : "http://www.example.com/foo",
+  "out" : "http://www.example.com/foo"
+}, {
+  "in" : "http://www.example.com/你好你好",
+  "out" : "http://www.example.com/%E4%BD%A0%E5%A5%BD%E4%BD%A0%E5%A5%BD"
+}, {
+  "in" : "http://www.example.com/‥/foo",
+  "out" : "http://www.example.com/%E2%80%A5/foo"
+}, {
+  "in" : "http://www.example.com/﻿/foo",
+  "out" : "http://www.example.com/%EF%BB%BF/foo"
+}, {
+  "in" : "http://www.example.com/‮/foo/‭/bar",
+  "out" : "http://www.example.com/%E2%80%AE/foo/%E2%80%AD/bar"
+}, {
+  "in" : "http://www.example.com／foo/",
+  "out" : "http://www.example.com/foo/"
+}, {
+  "in" : "http://www.example.com:8080/",
+  "out" : "http://www.example.com:8080/"
+}, {
+  "in" : "http://www.example.com:/",
+  "out" : "http://www.example.com/"
+}, {
+  "in" : "http://www.example.com/?foo=bar",
+  "out" : "http://www.example.com/?foo=bar"
+}, {
+  "in" : "http://www.example.com/?as?df",
+  "out" : "http://www.example.com/?as?df"
+}, {
+  "in" : "http://www.example.com/?q=\"asdf\"",
+  "out" : "http://www.example.com/?q=%22asdf%22"
+}, {
+  "in" : "http://host/",
+  "out" : "http://host/"
+}, {
+  "in" : "http://another/",
+  "out" : "http://another/"
+}, {
+  "in" : "http://host/",
+  "out" : "http://host/"
+}, {
+  "in" : "http://example.com/",
+  "out" : "http://example.com/"
+}, {
+  "in" : "HTTP://example.com/",
+  "out" : "http://example.com/"
+}, {
+  "in" : "http://www.google.com/foo?bar=baz#",
+  "out" : "http://www.google.com/foo?bar=baz#"
+}, {
+  "in" : "http://foo:81/",
+  "out" : "http://foo:81/"
+}, {
+  "in" : "https://foo:80/",
+  "out" : "https://foo:80/"
+}, {
+  "in" : "ftp://foo:80/",
+  "out" : "ftp://foo:80/"
+}, {
+  "in" : "http://example.com/",
+  "out" : "http://example.com/"
+}, {
+  "in" : "http://search.barnesandnoble.com/booksearch/first book.pdf", 
+  "out" : "http://search.barnesandnoble.com/booksearch/first%20book.pdf"
+}, {
+  "in" : "http://example.com/query?q=random word £500 bank $", 
+  "out" : "http://example.com/query?q=random%20word%20%C2%A3500%20bank%20$"
+}, {
+  "in" : "http://betatruebaonline.com/img/parte/330/CIGUEÑAL.JPG", 
+  "out" : "http://betatruebaonline.com/img/parte/330/CIGUE%C3%91AL.JPG"
+}, {
+  "in" : "http://GOO​⁠﻿goo.urltest.lookout.net/",
+  "out" : "http://googoo.urltest.lookout.net/"
+}, {
+  "in" : "http://www.foo。bar.urltest.lookout.net/",
+  "out" : "http://www.foo.bar.urltest.lookout.net/"
+}, {
+  "in" : "http://Ｇｏ.urltest.lookout.net/",
+  "out" : "http://go.urltest.lookout.net/"
+}, {
+  "in" : "http://你好你好.urltest.lookout.net/",
+  "out" : "http://xn--6qqa088eba.urltest.lookout.net/"
+}, {
+  "in" : "http://192.168.0.257.urltest.lookout.net/",
+  "out" : "http://192.168.0.257.urltest.lookout.net/"
+}, {
+  "in" : "http://faß.de.urltest.lookout.net/",
+  "out" : "http://fass.de.urltest.lookout.net/"
+}, {
+  "in" : "http://βόλος.urltest.lookout.net/",
+  "out" : "http://xn--nxasmq6b.urltest.lookout.net/"
+}, {
+  "in" : "http://ශ්‍රී.urltest.lookout.net/",
+  "out" : "http://xn--10cl1a0b.urltest.lookout.net/"
+}, {
+  "in" : "http://نامه‌ای.urltest.lookout.net/",
+  "out" : "http://xn--mgba3gch31f.urltest.lookout.net/"
+}, {
+  "in" : "http://www.looĸout.urltest.lookout.net/",
+  "out" : "http://www.xn--looout-5bb.urltest.lookout.net/"
+}, {
+  "in" : "http://ᗯᗯᗯ.urltest.lookout.net/",
+  "out" : "http://xn--1qeaa.urltest.lookout.net/"
+}, {
+  "in" : "http://www.lookout.сом.urltest.lookout.net/",
+  "out" : "http://www.lookout.xn--l1adi.urltest.lookout.net/"
+}, {
+  "in" : "http://www.lookout‧net.urltest.lookout.net/",
+  "out" : "http://www.xn--lookoutnet-406e.urltest.lookout.net/"
+}, {
+  "in" : "http://www.looĸout.urltest.lookout.net/",
+  "out" : "http://www.xn--looout-5bb.urltest.lookout.net/"
+}, {
+  "in" : "http://Bücher.de.urltest.lookout.net/",
+  "out" : "http://xn--bcher-kva.de.urltest.lookout.net/"
+}, {
+  "in" : "http://look͏out.urltest.lookout.net/",
+  "out" : "http://lookout.urltest.lookout.net/"
+}, {
+  "in" : "http://urltest.lookout.net/foo/..bar",
+  "out" : "http://urltest.lookout.net/foo/..bar"
+}, {
+  "in" : "http://urltest.lookout.net/foo",
+  "out" : "http://urltest.lookout.net/foo"
+}, {
+  "in" : "http://urltest.lookout.net/你好你好",
+  "out" : "http://urltest.lookout.net/%E4%BD%A0%E5%A5%BD%E4%BD%A0%E5%A5%BD"
+}, {
+  "in" : "http://urltest.lookout.net/‥/foo",
+  "out" : "http://urltest.lookout.net/%E2%80%A5/foo"
+}, {
+  "in" : "http://urltest.lookout.net/﻿/foo",
+  "out" : "http://urltest.lookout.net/%EF%BB%BF/foo"
+}, {
+  "in" : "http://urltest.lookout.net/‮/foo/‭/bar",
+  "out" : "http://urltest.lookout.net/%E2%80%AE/foo/%E2%80%AD/bar"
+}, {
+  "in" : "http://urltest.lookout.net／foo/",
+  "out" : "http://urltest.lookout.net/foo/"
+}, {
+  "in" : "http://urltest.lookout.net/?foo=bar",
+  "out" : "http://urltest.lookout.net/?foo=bar"
+}, {
+  "in" : "http://urltest.lookout.net/?as?df",
+  "out" : "http://urltest.lookout.net/?as?df"
+}, {
+  "in" : "http://urltest.lookout.net/?q=\"asdf\"",
+  "out" : "http://urltest.lookout.net/?q=%22asdf%22"
+}, {
+  "in" : "http://another.urltest.lookout.net/",
+  "out" : "http://another.urltest.lookout.net/"
+}, {
+  "in" : "http://urltest.lookout.net/foo?bar=baz#",
+  "out" : "http://urltest.lookout.net/foo?bar=baz#"
+}, {
+  "in" : "http://urltest.lookout.net/",
+  "out" : "http://urltest.lookout.net/"
+}]
+}


### PR DESCRIPTION
Hallo @inkuss ,
da ich mich gerade an anderer Stelle mit URL-Encoding beschäftigt habe, bin ich bei der Gelegenheit mal über das URL-Encoding in WebgathererUtils gegangen und habe es etwas aufgeräumt. Durch den neu hinzugekommenen Test versuche ich sicherzustellen, dass die neue Implementation mindestens so gut ist wie die alte. Tatsächlich ist sie m.E. sogar etwas besser. Wenn du 
da02c40  auscheckst, kannst du im Test den direkten Vergleich anschauen. 

In  der Datei test/resources/url-succeding-tests.json kannst Du sehen, wie sich das Encoding verhält. Hier kann man auch neue Fälle hinzufügen. 