### PR TITLE
Edozwo 822

### DIFF
--- a/app/actions/Create.java
+++ b/app/actions/Create.java
@@ -20,11 +20,13 @@ import static archive.fedora.Vocabulary.TYPE_OBJECT;
 
 import java.io.File;
 import java.math.BigInteger;
+import java.net.URISyntaxException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import com.fasterxml.jackson.databind.JsonNode;
 import helper.HttpArchiveException;
+import helper.WebgatherUtils;
 import helper.mail.WebgatherExceptionMail;
 import helper.oai.OaiDispatcher;
 import helper.WpullCrawl;
@@ -242,8 +244,10 @@ public class Create extends RegalAction {
 	/**
 	 * @param n must be of type webpage
 	 * @return a new version pointing to a heritrix crawl
+	 * @throws URISyntaxException eine URISyntaxException
 	 */
 	public Node createWebpageVersion(Node n) {
+
 		Gatherconf conf = null;
 		File crawlDir = null;
 		String localpath = null;
@@ -257,6 +261,7 @@ public class Create extends RegalAction {
 			WebgatherLogger
 					.debug("Create webpageVersion with conf " + conf.toString());
 			conf.setName(n.getPid());
+
 			if (conf.getCrawlerSelection()
 					.equals(Gatherconf.CrawlerSelection.heritrix)) {
 				if (Globals.heritrix.isBusy()) {

--- a/app/helper/Webgatherer.java
+++ b/app/helper/Webgatherer.java
@@ -35,6 +35,12 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map.Entry;
 
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+
 import com.ibm.icu.util.Calendar;
 
 import models.Gatherconf;
@@ -357,6 +363,7 @@ public class Webgatherer implements Runnable {
 			HttpURLConnection httpConnection = (HttpURLConnection) new URL(
 					WebgatherUtils.convertUnicodeURLToAscii(conf.getUrl()))
 							.openConnection();
+			setFollowRedirects(httpConnection, false);
 			httpConnection.setRequestMethod("GET");
 			int httpResponseCode = httpConnection.getResponseCode();
 			WebgatherLogger.debug("httpResponseCode=" + httpResponseCode);
@@ -385,6 +392,38 @@ public class Webgatherer implements Runnable {
 					.error("Url " + conf.getUrl() + " konnte nicht überprüft werden.");
 			throw new RuntimeException(e);
 		}
+	}
+
+	private static void setFollowRedirects(HttpURLConnection httpConnection,
+			boolean follow) {
+		httpConnection.setFollowRedirects(follow);
+	}
+
+	/**
+	 * Here is how I get status code from HttpClient, which I like very much: From
+	 * user https://stackoverflow.com/users/2917711/lw0 at stackoverflow, 20.März
+	 * 2014
+	 **/
+	public static int getUrlHttpResponseStatusCode(String uri) {
+		CloseableHttpResponse response = null;
+		int statusCode = -1;
+		try {
+			CloseableHttpClient client = HttpClients.createDefault();
+			HttpHead headReq = new HttpHead(uri);
+			response = client.execute(headReq);
+			StatusLine sl = response.getStatusLine();
+			statusCode = sl.getStatusCode();
+		} catch (Exception e) {
+			WebgatherLogger.error("Error in HttpGroovySourse : " + e.getMessage(), e);
+		} finally {
+			try {
+				response.close();
+			} catch (Exception e) {
+				WebgatherLogger.error("Error in HttpGroovySourse : " + e.getMessage(),
+						e);
+			}
+		}
+		return statusCode;
 	}
 
 }

--- a/app/helper/WpullCrawl.java
+++ b/app/helper/WpullCrawl.java
@@ -203,7 +203,7 @@ public class WpullCrawl {
 		}
 
 		int level = conf.getDeepness();
-		if (level != 0) {
+		if (level > 0) {
 			sb.append(" --level=" + Integer.toString(level)); // number of recursions
 		}
 

--- a/app/models/Gatherconf.java
+++ b/app/models/Gatherconf.java
@@ -484,36 +484,4 @@ public class Gatherconf {
 		this.httpResponseCode = httpResponseCode;
 	}
 
-	/**
-	 * Stellt fest, ob die URL umgezogen ist.
-	 * 
-	 * @return ob die URL der Webpage umgezogen ist
-	 * @exception MalformedURLException
-	 * @exception IOException
-	 */
-	public boolean hasUrlMoved()
-			throws URISyntaxException, MalformedURLException, IOException {
-
-		if (invalidUrl) {
-			return true;
-		} // keine erneute Prüfung
-		HttpURLConnection httpConnection = (HttpURLConnection) new URL(
-				WebgatherUtils.convertUnicodeURLToAscii(url)).openConnection();
-		httpConnection.setRequestMethod("GET");
-		httpResponseCode = httpConnection.getResponseCode();
-		if (httpResponseCode != 301) {
-			return false;
-		}
-		// ermiitelt die neue URL (falls bekannt)
-		urlNew = null;
-		for (Entry<String, List<String>> header : httpConnection.getHeaderFields()
-				.entrySet()) {
-			if (header.getKey() != null && header.getKey().equals("Location")) {
-				urlNew = header.getValue().get(0);
-			}
-		}
-		httpConnection.disconnect();
-		return true;
-	}
-
 }

--- a/app/models/Gatherconf.java
+++ b/app/models/Gatherconf.java
@@ -126,7 +126,7 @@ public class Gatherconf {
 		interval = null;
 		crawlerSelection = CrawlerSelection.heritrix;
 		quotaUnitSelection = null;
-		agentIdSelection = null;
+		agentIdSelection = AgentIdSelection.Undefined;
 		urlsExcluded = new ArrayList<String>();
 		startDate = null;
 		localDir = null;


### PR DESCRIPTION
This fixes two errors which have occured during pre-testing of Website Gathering on edoweb-test.
1. Detection of moved (=redirected) websites. Code refactored (Webgatherer.java, Gatherconf.java). Set parameter followRedirects to false in class HttpURLConnection.
2. Initial parameters for wpull Crawls were erroneously set. Set agentIdSelection to "Undefined" (was: null). Allow level = -1 (only set this parameter in wpull if level > 0 (was: if level !=0)). In class Webgatherer.java

This fixes the two problems. The code has been rolled out on edoweb-test.