### PR TITLE
bugfix: text 'testis' is displayed as local link

### DIFF
--- a/app/views/Helper.java
+++ b/app/views/Helper.java
@@ -575,7 +575,7 @@ public class Helper {
 
 	public static String getLinkAdressOrNull(String value) {
 		for (String n : Globals.namespaces) {
-			if (value.startsWith(n)) {
+			if (value.startsWith(n + ":")) {
 				return "/resource/" + value;
 			}
 		}


### PR DESCRIPTION
- analysis: this happens when 'test' is configured as a valid
namespace and normal field value just start with that
string
- fix: modify link routine by appending an additional colon,
to look for {namespace}:, e.g. "test:" instead of "test"