### PR TITLE
Edozwo 837

### DIFF
--- a/app/helper/Heritrix.java
+++ b/app/helper/Heritrix.java
@@ -157,8 +157,9 @@ public class Heritrix {
 			content = content.replaceAll("\\$\\{DESCRIPTION\\}",
 					"Edoweb crawl of" + conf.getUrl());
 			content = content.replaceAll("\\$\\{URL\\}", conf.getUrl());
-			content = content.replaceAll("\\$\\{URL_NO_WWW\\}", "http://"
-					+ conf.getUrl().replaceAll("^http://", "").replaceAll("^www\\.", ""));
+			content =
+					content.replaceAll("\\$\\{URL_NO_WWW\\}", "http://" + conf.getUrl()
+							.replaceAll("^http://|https://", "").replaceAll("^www\\.", ""));
 			content = content.replaceAll("\\$\\{URL_SURT_FORM\\}",
 					urlSurtForm(conf.getUrl()));
 			ArrayList<String> domains = conf.getDomains();
@@ -190,8 +191,8 @@ public class Heritrix {
 	 * @return the SURT form of the url
 	 */
 	private static String urlSurtForm(String url) {
-		String urlRaw = url.replaceAll("^http://", "").replaceAll("^www\\.", "")
-				.replaceAll("/$", "");
+		String urlRaw = url.replaceAll("^http://|https://", "")
+				.replaceAll("^www\\.", "").replaceAll("/$", "");
 		String[] urlParts = urlRaw.split("\\.");
 		String urlSurtForm = "+http://(";
 		for (int i = urlParts.length - 1; i >= 0; i--) {

--- a/conf/crawler-beans.cxml
+++ b/conf/crawler-beans.cxml
@@ -129,7 +129,7 @@ ${URL}
  <!-- SCOPE: rules for which discovered URIs to crawl; order is very 
       important because last decision returned other than 'NONE' wins. -->
  <bean id="scope" class="org.archive.modules.deciderules.DecideRuleSequence">
-  <property name="logToFile" value="true" />
+  <property name="logToFile" value="false" />
   <property name="rules">
    <list>
     <!-- Begin by REJECTing all... -->


### PR DESCRIPTION
merged into branch "test" on edoweb-test and tested there:
- no new scope.log is created when a new crawl is started. There is only one single scope log on the whole system 
- SURTs for sites using the https protocol are being created correctly.
OK.
Test site: https://edoweb-test.hbz-nrw.de/resource/edoweb:5951021