### PR TITLE
Fix. The "zuletzt hinzugefügtes Label" is missing

### DIFF
--- a/app/models/Node.java
+++ b/app/models/Node.java
@@ -1240,7 +1240,6 @@ public class Node implements java.io.Serializable {
 	/**
 	 * @return a map representing the rdf data on this object
 	 */
-	@JsonValue
 	public Map<String, Object> getLd1() {
 		Map<String, Object> result = new JsonMapper(this).getLd();
 		if ("D".equals(getState())) {
@@ -1274,6 +1273,7 @@ public class Node implements java.io.Serializable {
 		}
 	}
 
+	@JsonValue
 	public Map<String, Object> getLd2() {
 		Map<String, Object> result = new JsonMapper(this).getLd2();
 		if ("D".equals(getState())) {


### PR DESCRIPTION
- the api call returns a json serialization of Node.java. The Node.java
uses the annotation @JsonValue to provide proper values to the
serializer. Unfortunatly the annotation was still applied to
 the getLd1() method which provides metadata from the old lobid v1
metadata stream. This stream isn't used anymore. I added the
annotation to the getLd2() method.