### PR TITLE
fix: file inherits title form parent after move

### DIFF
--- a/app/models/Node.java
+++ b/app/models/Node.java
@@ -625,6 +625,8 @@ public class Node implements java.io.Serializable {
 	 */
 	@JsonIgnore()
 	public String getMetadata2() {
+		if (metadata2 == null || metadata2.isEmpty())
+			return metadata1;
 		return metadata2;
 	}
 


### PR DESCRIPTION
- This fix should solve an inconsistency between older objects
and newer objects. While older objects store their titles in a
stream called /metadata, newer objects use the /metadata2 stream
to store title information.
- To mimic the behaviour of newer objects I introduce this patch
which will return the content of /metadata if no /metadata2
stream is present.
- This patch should presumably only apply to objects of type file,
part or article. All other objects should have been actively
migrated and thus contain metadata2 streams.