### PR TITLE
fix: EDOZWO-806 "zuletzt hinzugefügtes Label" missing

### DIFF
--- a/app/controllers/Resource.java
+++ b/app/controllers/Resource.java
@@ -1013,7 +1013,7 @@ public class Resource extends MyController {
 					response().setHeader("Content-Type", "text/html; charset=utf-8");
 					return ok(resource.render(result, null));
 				} else {
-					return getJsonResult(result);
+					return getJsonResult(result.getLd2());
 				}
 			} catch (Exception e) {
 				return JsonMessage(new Message(e, 500));


### PR DESCRIPTION
- return metadata on basis of metadata2, since for
newer objects the metadata1 stream does not contain
descriptive metadata.