### PR TITLE
Frl-444

### DIFF
--- a/app/Global.java
+++ b/app/Global.java
@@ -18,7 +18,9 @@
 import static play.mvc.Results.notFound;
 
 import java.lang.reflect.Method;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -128,10 +130,23 @@ public class Global extends GlobalSettings {
 
 	@Override
 	public Action onRequest(Request request, Method actionMethod) {
-		play.Logger.info(
+		String host = request.getHeader("Host");
+		String date = getDate();
+		String httpReq = request.toString();
+		String agent = request.getHeader("User-Agent");
+		String userIp = request.getHeader("UserIp");
+
+		play.Logger.info(String.format("%s %s [%s]  \"%s\" %s", host, userIp, date,
+				httpReq, agent));
+		play.Logger.debug(
 				"\n" + request.toString() + "\n\t" + mapToString(request.headers()));
-		play.Logger.debug("\t" + request.body().toString());
 		return super.onRequest(request, actionMethod);
+	}
+
+	private String getDate() {
+		SimpleDateFormat simpleDateFormat =
+				new SimpleDateFormat("dd/mm/yyyy:hh:mm:ss +SSS");
+		return simpleDateFormat.format(new Date());
 	}
 
 	private static String mapToString(Map<String, String[]> map) {

--- a/app/actions/Enrich.java
+++ b/app/actions/Enrich.java
@@ -6,6 +6,7 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.text.Normalizer;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -34,15 +35,13 @@ import helper.MyEtikettMaker;
 import models.Globals;
 import models.Node;
 
+/**
+ * Add a label for each uri
+ * 
+ * @author Jan Schnasse
+ *
+ */
 public class Enrich {
-	private static final String alternateName =
-			"http://www.geonames.org/ontology#alternateName";
-	private static final String first =
-			"http://www.w3.org/1999/02/22-rdf-syntax-ns#first";
-	private static final String rest =
-			"http://www.w3.org/1999/02/22-rdf-syntax-ns#rest";
-	private static final String nil =
-			"http://www.w3.org/1999/02/22-rdf-syntax-ns#nil";
 
 	private static final String PREF_LABEL =
 			"http://www.w3.org/2004/02/skos/core#prefLabel";
@@ -67,7 +66,7 @@ public class Enrich {
 		return "Enrichment of " + node.getPid() + " succeeded!";
 	}
 
-	public static String enrichMetadata(Node node) {
+	public static String enrichMetadata1(Node node) {
 		try {
 			play.Logger.info("Enrich " + node.getPid());
 			String metadata = node.getMetadata1();
@@ -91,137 +90,8 @@ public class Enrich {
 
 	private static void enrichAll(Node node, String metadata,
 			List<Statement> enrichStatements) {
-		enrichGnd(node, metadata, enrichStatements);
-
-		enrichGeonames(node, metadata, enrichStatements);
-
-		enrichOsm(node, metadata, enrichStatements);
-
-		enrichOrcid(node, metadata, enrichStatements);
-
-		enrichAdhocIds(node, metadata, enrichStatements);
-
-		enrichAgrovoc(node, metadata, enrichStatements);
-
 		enrichInstitution(node, enrichStatements);
-
-		enrichIsPartOf(node, metadata, enrichStatements);
-
-		enrichSeries(node, metadata, enrichStatements);
-
-		enrichMultivolumeWork(node, metadata, enrichStatements);
-
-		enrichLanguage(node, metadata, enrichStatements);
-
-		enrichRecordingLocation(node, metadata, enrichStatements);
-
-		enrichCollectionOne(node, metadata, enrichStatements);
-
-		enrichCollectionTwo(node, metadata, enrichStatements);
-
-		enrichContainedIn(node, metadata, enrichStatements);
-
-		enrichFundingId(node, metadata, enrichStatements);
-	}
-
-	private static void enrichFundingId(Node node, String metadata,
-			List<Statement> enrichStatements) {
-		try {
-			play.Logger.debug("ENRICH FUNDING!-----------------------------");
-			enrichStatements
-					.addAll(find(node, metadata, "http://hbz-nrw.de/regal#fundingId"));
-		} catch (Exception e) {
-			play.Logger.debug("", e);
-		}
-	}
-
-	private static void enrichContainedIn(Node node, String metadata,
-			List<Statement> enrichStatements) {
-		try {
-			List<Statement> containedIn =
-					find(node, metadata, "http://purl.org/lobid/lv#containedIn");
-			enrichStatements.addAll(containedIn);
-		} catch (Exception e) {
-			play.Logger.debug("", e);
-		}
-	}
-
-	private static void enrichCollectionTwo(Node node, String metadata,
-			List<Statement> enrichStatements) {
-		try {
-			List<Statement> collectionTwo =
-					find(node, metadata, "info:regal/zettel/collectionTwo");
-			enrichStatements.addAll(collectionTwo);
-		} catch (Exception e) {
-			play.Logger.debug("", e);
-		}
-	}
-
-	private static void enrichCollectionOne(Node node, String metadata,
-			List<Statement> enrichStatements) {
-		List<Statement> collectionOne =
-				find(node, metadata, "info:regal/zettel/collectionOne");
-		enrichStatements.addAll(collectionOne);
-	}
-
-	private static void enrichRecordingLocation(Node node, String metadata,
-			List<Statement> enrichStatements) {
-		try {
-			play.Logger.info("Enrich " + node.getPid() + " with recordingLocation.");
-			List<Statement> recordingLocation =
-					find(node, metadata, "http://hbz-nrw.de/regal#recordingLocation");
-			enrichStatements.addAll(recordingLocation);
-		} catch (Exception e) {
-			play.Logger.debug("", e);
-		}
-	}
-
-	private static void enrichLanguage(Node node, String metadata,
-			List<Statement> enrichStatements) {
-		try {
-			play.Logger.info("Enrich " + node.getPid() + " with language.");
-			List<Statement> language =
-					find(node, metadata, "http://purl.org/dc/terms/language");
-			enrichStatements.addAll(language);
-		} catch (Exception e) {
-			play.Logger.debug("", e);
-		}
-	}
-
-	private static void enrichMultivolumeWork(Node node, String metadata,
-			List<Statement> enrichStatements) {
-		try {
-			play.Logger.info("Enrich " + node.getPid() + " with multiVolumeWork.");
-			List<Statement> multiVolumeWork =
-					find(node, metadata, "http://purl.org/lobid/lv#multiVolumeWork");
-			enrichStatements.addAll(multiVolumeWork);
-		} catch (Exception e) {
-			play.Logger.debug("", e);
-		}
-	}
-
-	private static void enrichSeries(Node node, String metadata,
-			List<Statement> enrichStatements) {
-		try {
-			play.Logger.info("Enrich " + node.getPid() + " with inSeries.");
-			List<Statement> series =
-					find(node, metadata, "http://purl.org/lobid/lv#series");
-			enrichStatements.addAll(series);
-		} catch (Exception e) {
-			play.Logger.debug("", e);
-		}
-	}
-
-	private static void enrichIsPartOf(Node node, String metadata,
-			List<Statement> enrichStatements) {
-		try {
-			play.Logger.info("Enrich " + node.getPid() + " with parent.");
-			List<Statement> catalogParents =
-					find(node, metadata, "http://purl.org/dc/terms/isPartOf");
-			enrichStatements.addAll(catalogParents);
-		} catch (Exception e) {
-			play.Logger.debug("", e);
-		}
+		enrichAllUris(node, metadata, enrichStatements);
 	}
 
 	private static void enrichInstitution(Node node,
@@ -233,108 +103,6 @@ public class Enrich {
 		} catch (Exception e) {
 			play.Logger.debug("", e);
 		}
-	}
-
-	private static void enrichAgrovoc(Node node, String metadata,
-			List<Statement> enrichStatements) {
-		try {
-			play.Logger.info("Enrich " + node.getPid() + " with agrovoc.");
-			List<String> agrovocIds = findAllAgrovocIds(metadata);
-			for (String uri : agrovocIds) {
-				enrichStatements.addAll(getAgrovocStatements(uri));
-			}
-		} catch (Exception e) {
-			play.Logger.debug("", e);
-		}
-	}
-
-	private static void enrichAdhocIds(Node node, String metadata,
-			List<Statement> enrichStatements) {
-		try {
-			play.Logger.info("Enrich " + node.getPid() + " with adhoc keys.");
-			List<String> adhocIds = findAllAdhocIds(metadata);
-			for (String uri : adhocIds) {
-				enrichStatements.addAll(getAdhocStatements(uri));
-			}
-		} catch (Exception e) {
-			play.Logger.debug("", e);
-		}
-	}
-
-	private static void enrichOrcid(Node node, String metadata,
-			List<Statement> enrichStatements) {
-		try {
-			play.Logger.info("Enrich " + node.getPid() + " with orcid.");
-			List<String> orcidIds = findAllOrcidIds(metadata);
-			for (String uri : orcidIds) {
-				enrichStatements.addAll(getOrcidStatements(uri));
-			}
-		} catch (Exception e) {
-			play.Logger.debug("", e);
-		}
-	}
-
-	private static void enrichOsm(Node node, String metadata,
-			List<Statement> enrichStatements) {
-		try {
-			play.Logger.info("Enrich " + node.getPid() + " with openstreetmap.");
-			List<String> osmIds = findAllOsmIds(metadata);
-			for (String uri : osmIds) {
-				enrichStatements.addAll(getOsmStatements(uri));
-			}
-		} catch (Exception e) {
-			play.Logger.debug("", e);
-		}
-	}
-
-	private static void enrichGeonames(Node node, String metadata,
-			List<Statement> enrichStatements) {
-		try {
-			play.Logger.info("Enrich " + node.getPid() + " with geonames.");
-			List<String> geoNameIds = findAllGeonameIds(metadata);
-			for (String uri : geoNameIds) {
-				enrichStatements.addAll(getGeonamesStatements(uri));
-			}
-		} catch (Exception e) {
-			play.Logger.debug("", e);
-		}
-	}
-
-	private static void enrichGnd(Node node, String metadata,
-			List<Statement> enrichStatements) {
-		try {
-			play.Logger.info("Enrich " + node.getPid() + " with gnd.");
-			List<String> gndIds = findAllGndIds(metadata);
-			for (String uri : gndIds) {
-				enrichStatements.addAll(getStatements(uri));
-			}
-		} catch (Exception e) {
-			play.Logger.debug("", e);
-		}
-	}
-
-	private static List<Statement> find(Node node, String metadata, String pred) {
-		List<Statement> result = new ArrayList<Statement>();
-		// getIsPartOf
-
-		List<String> statements = RdfUtils.findRdfObjects(node.getPid(), pred,
-				metadata, RDFFormat.NTRIPLES);
-		for (String p : statements) {
-			ValueFactory v = RdfUtils.valueFactory;
-			String label = getEtikett(p);
-			Statement st = v.createStatement(v.createIRI(p), v.createIRI(PREF_LABEL),
-					v.createLiteral(Normalizer.normalize(label, Normalizer.Form.NFKC)));
-			result.add(st);
-			play.Logger.debug(
-					"Found on " + pred + " -> object: " + st.getObject().stringValue()
-							+ " -> subject: " + st.getSubject().stringValue());
-		}
-		return result;
-	}
-
-	private static String getEtikett(String p) {
-		String prefLabel = MyEtikettMaker.getLabelFromEtikettWs(p);
-		return prefLabel;
 	}
 
 	private static List<Statement> findInstitution(Node node) {
@@ -367,7 +135,7 @@ public class Enrich {
 							v.createIRI("http://dbpedia.org/ontology/institution"),
 							v.createIRI(gndId));
 					result.add(link);
-					result.addAll(getStatements(gndId));
+					result.add(getLabelStatement(gndId));
 				}
 
 			}
@@ -379,271 +147,46 @@ public class Enrich {
 		return result;
 	}
 
-	private static List<Statement> getStatements(String uri) {
-		play.Logger.info("GET " + uri);
-		List<Statement> filteredStatements = new ArrayList<Statement>();
+	private static void enrichAllUris(Node node, String metadata,
+			List<Statement> enrichStatements) {
 		try {
-			for (Statement s : RdfUtils.readRdfToGraph(new URL(uri + "/about/lds"),
-					RDFFormat.RDFXML, "application/rdf+xml")) {
-				boolean isLiteral = s.getObject() instanceof Literal;
-				if (!(s.getSubject() instanceof BNode)) {
-					if (isLiteral) {
-						ValueFactory v = RdfUtils.valueFactory;
-
-						play.Logger.trace("Get data from " + uri);
-						Statement newS = v.createStatement(v.createIRI(uri),
-								s.getPredicate(), v.createLiteral(Normalizer.normalize(
-										s.getObject().stringValue(), Normalizer.Form.NFKC)));
-						filteredStatements.add(newS);
-					}
-				}
+			List<String> allUris = findAllUris(metadata);
+			for (String uri : allUris) {
+				enrich(uri, enrichStatements);
 			}
 		} catch (Exception e) {
-			play.Logger.warn("Not able to get data from" + uri, e);
-		}
-		return filteredStatements;
-	}
-
-	private static List<Statement> getOrcidStatements(String uri) {
-		play.Logger.trace("GET " + uri);
-		List<Statement> filteredStatements = new ArrayList<Statement>();
-		try (InputStream in =
-				RdfUtils.urlToInputStream(new URL(uri), "application/json")) {
-			String str =
-					CharStreams.toString(new InputStreamReader(in, Charsets.UTF_8));
-			JsonNode hit = new ObjectMapper().readValue(str, JsonNode.class);
-			String label = hit.at("/person/name/family-name/value").asText() + ", "
-					+ hit.at("/person/name/given-names/value").asText();
-			ValueFactory v = RdfUtils.valueFactory;
-			Literal object =
-					v.createLiteral(Normalizer.normalize(label, Normalizer.Form.NFKC));
-			Statement newS =
-					v.createStatement(v.createIRI(uri), v.createIRI(PREF_LABEL), object);
-			play.Logger.trace("Get data from " + uri + " " + newS);
-			filteredStatements.add(newS);
-		} catch (Exception e) {
-			play.Logger.warn("", e);
-		}
-		return filteredStatements;
-	}
-
-	private static List<Statement> getAdhocStatements(String uri) {
-		play.Logger.info("GET " + uri);
-		List<Statement> filteredStatements = new ArrayList<Statement>();
-		try {
-			for (Statement s : RdfUtils.readRdfToGraph(new URL(uri), RDFFormat.RDFXML,
-					"application/rdf+xml")) {
-				boolean isLiteral = s.getObject() instanceof Literal;
-				if (!(s.getSubject() instanceof BNode)) {
-					if (isLiteral) {
-						ValueFactory v = RdfUtils.valueFactory;
-
-						play.Logger.trace("Get data from " + uri);
-						Statement newS = v.createStatement(v.createIRI(uri),
-								s.getPredicate(), v.createLiteral(Normalizer.normalize(
-										s.getObject().stringValue(), Normalizer.Form.NFKC)));
-						filteredStatements.add(newS);
-					}
-				}
-			}
-		} catch (Exception e) {
-			play.Logger.warn("Not able to get data from" + uri, e);
-		}
-		return filteredStatements;
-	}
-
-	private static List<Statement> getOsmStatements(String uri) {
-		play.Logger.trace("GET " + uri);
-		List<Statement> filteredStatements = new ArrayList<Statement>();
-		try {
-			URL url = new URL(uri);
-			Map<String, String> map = new LinkedHashMap<String, String>();
-			String query = url.getQuery();
-			for (String pair : query.split("&")) {
-				String[] keyValue = pair.split("=");
-				int idx = pair.indexOf("=");
-				map.put(URLDecoder.decode(keyValue[0], "UTF-8"),
-						URLDecoder.decode(keyValue[1], "UTF-8"));
-			}
-			ValueFactory v = RdfUtils.valueFactory;
-			Literal object = v.createLiteral(Normalizer.normalize(
-					map.get("mlat") + "," + map.get("mlon"), Normalizer.Form.NFKC));
-			Statement newS =
-					v.createStatement(v.createIRI(uri), v.createIRI(PREF_LABEL), object);
-			play.Logger.trace("Get data from " + uri + " " + newS);
-			filteredStatements.add(newS);
-		} catch (Exception e) {
-			play.Logger.warn(e.getMessage());
 			play.Logger.debug("", e);
 		}
-		return filteredStatements;
 	}
 
-	private static List<Statement> getGeonamesStatements(String uri) {
-		play.Logger.trace("GET " + uri);
-		ValueFactory vf = SimpleValueFactory.getInstance();
-		List<Statement> filteredStatements = new ArrayList<Statement>();
-		List<Literal> alternateNames = new ArrayList<Literal>();
+	private static void enrich(String uri, List<Statement> enrichStatements) {
 		try {
-			for (Statement s : RdfUtils.readRdfToGraph(new URL(uri + "/about.rdf"),
-					RDFFormat.RDFXML, "application/rdf+xml")) {
-				boolean isLiteral = s.getObject() instanceof Literal;
-				if (!(s.getSubject() instanceof BNode)) {
-					if (isLiteral) {
-						Literal l = (Literal) s.getObject();
-						Literal object = vf.createLiteral(Normalizer
-								.normalize(s.getObject().stringValue(), Normalizer.Form.NFKC),
-								l.getLanguage().get());
-						Statement newS =
-								vf.createStatement(vf.createIRI(uri), s.getPredicate(), object);
-						play.Logger.trace("Get data from " + uri + " " + newS);
-
-						if (alternateName.equals(s.getPredicate().stringValue())) {
-							newS = vf.createStatement(vf.createIRI(uri), vf.createIRI(
-									s.getPredicate().stringValue() + "_" + object.getLanguage()),
-									object);
-						}
-						filteredStatements.add(newS);
-					}
-				}
-			}
+			Statement label = getLabelStatement(uri);
+			play.Logger
+					.info("Add label " + label.getObject().stringValue() + " to " + uri);
+			enrichStatements.add(label);
 		} catch (Exception e) {
-			play.Logger.warn("Not able to get data from" + uri);
+			play.Logger.debug("", e);
 		}
-
-		return filteredStatements;
 	}
 
-	private static List<Statement> getAgrovocStatements(String uri) {
-		play.Logger.trace("GET " + uri);
-		ValueFactory vf = SimpleValueFactory.getInstance();
-		List<Statement> filteredStatements = new ArrayList<Statement>();
-		List<Literal> prefLabel = new ArrayList<Literal>();
-		try {
-			for (Statement s : RdfUtils.readRdfToGraph(new URL(uri), RDFFormat.RDFXML,
-					"application/rdf+xml")) {
-				boolean isLiteral = s.getObject() instanceof Literal;
-				if (!(s.getSubject() instanceof BNode)) {
-					if (isLiteral) {
-						Literal l = (Literal) s.getObject();
-						Literal object = vf.createLiteral(Normalizer
-								.normalize(s.getObject().stringValue(), Normalizer.Form.NFKC),
-								l.getLanguage().get());
-						Statement newS =
-								vf.createStatement(vf.createIRI(uri), s.getPredicate(), object);
-						play.Logger.trace("Get data from " + uri + " " + newS);
-
-						if (PREF_LABEL.equals(s.getPredicate().stringValue())) {
-							if ("de".equals(object.getLanguage())) {
-								newS = vf.createStatement(vf.createIRI(uri), s.getPredicate(),
-										object);
-								filteredStatements.add(newS);
-							}
-							newS = vf.createStatement(vf.createIRI(uri), vf.createIRI(
-									s.getPredicate().stringValue() + "_" + object.getLanguage()),
-									object);
-						}
-						filteredStatements.add(newS);
-					}
-				}
-			}
-		} catch (Exception e) {
-			play.Logger.warn("Not able to get data from" + uri);
-		}
-
-		return filteredStatements;
+	private static Statement getLabelStatement(String uri) {
+		String prefLabel = MyEtikettMaker.getLabelFromEtikettWs(uri);
+		ValueFactory v = RdfUtils.valueFactory;
+		Statement newS = v.createStatement(v.createIRI(uri),
+				v.createIRI(PREF_LABEL),
+				v.createLiteral(Normalizer.normalize(prefLabel, Normalizer.Form.NFKC)));
+		return newS;
 	}
 
-	private static List<Statement> getListAsStatements(List<Literal> list,
-			String uri, String predicate) {
-		List<Statement> listStatements = new ArrayList<Statement>();
-		ValueFactory vf = SimpleValueFactory.getInstance();
-		BNode head = vf.createBNode();
-		Statement newS =
-				vf.createStatement(vf.createIRI(uri), vf.createIRI(predicate), head);
-		listStatements.add(newS);
-
-		Resource cur = head;
-		for (Literal l : list) {
-			BNode r = vf.createBNode();
-			Statement linkToRest = vf.createStatement(cur, vf.createIRI(rest), r);
-			Statement linkToValue = vf.createStatement(cur, vf.createIRI(first), l);
-			cur = r;
-			listStatements.add(linkToRest);
-			listStatements.add(linkToValue);
-		}
-		Statement endOfList = listStatements.get(listStatements.size() - 1);
-		listStatements.remove(listStatements.size() - 1);
-		Statement linkToNill = vf.createStatement(endOfList.getSubject(),
-				vf.createIRI(rest), vf.createIRI(nil));
-		listStatements.add(linkToNill);
-		return listStatements;
-	}
-
-	private static List<String> findAllGndIds(String metadata) {
-		HashMap<String, String> result = new HashMap<String, String>();
-		Matcher m = Pattern.compile("http://d-nb.info/gnd/[1234567890-]*[A-Z]*")
-				.matcher(metadata);
-		while (m.find()) {
-			String id = m.group();
-			result.put(id, id);
-		}
-		return new Vector<String>(result.keySet());
-	}
-
-	private static List<String> findAllGeonameIds(String metadata) {
-		HashMap<String, String> result = new HashMap<String, String>();
-		Matcher m = Pattern.compile("http://www.geonames.org/[1234567890-]*")
-				.matcher(metadata);
-		while (m.find()) {
-			String id = m.group();
-			result.put(id, id);
-		}
-		return new Vector<String>(result.keySet());
-	}
-
-	private static List<String> findAllOsmIds(String metadata) {
-		HashMap<String, String> result = new HashMap<String, String>();
-		Matcher m =
-				Pattern.compile("http://www.openstreetmap.org/[^>]*").matcher(metadata);
-		while (m.find()) {
-			String id = m.group();
-			result.put(id, id);
-		}
-		return new Vector<String>(result.keySet());
-	}
-
-	private static List<String> findAllOrcidIds(String metadata) {
+	private static List<String> findAllUris(String metadata) {
 		HashMap<String, String> result = new HashMap<>();
-		Matcher m = Pattern.compile("https?://orcid.org/[^>]*").matcher(metadata);
+		Matcher m = Pattern.compile("(https?://[^>]*)> \\.").matcher(metadata);
 		while (m.find()) {
-			String id = m.group();
+			String id = m.group(1);
 			result.put(id, id);
 		}
-		return new Vector<String>(result.keySet());
-	}
-
-	private static List<String> findAllAdhocIds(String metadata) {
-		HashMap<String, String> result = new HashMap<>();
-		Matcher m =
-				Pattern.compile(Globals.protocol + Globals.server + "/adhoc/[^>]*")
-						.matcher(metadata);
-		while (m.find()) {
-			String id = m.group();
-			result.put(id, id);
-		}
-		return new Vector<String>(result.keySet());
-	}
-
-	private static List<String> findAllAgrovocIds(String metadata) {
-		HashMap<String, String> result = new HashMap<>();
-		Matcher m = Pattern.compile("http://aims.fao.org/aos/agrovoc/[^>]*")
-				.matcher(metadata);
-		while (m.find()) {
-			String id = m.group();
-			result.put(id, id);
-		}
-		return new Vector<String>(result.keySet());
+		return new Vector<>(result.keySet());
 	}
 
 }

--- a/app/actions/Enrich.java
+++ b/app/actions/Enrich.java
@@ -1,0 +1,649 @@
+package actions;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.w3c.dom.Element;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Charsets;
+import com.google.common.io.CharStreams;
+
+import archive.fedora.RdfUtils;
+import archive.fedora.XmlUtils;
+import helper.MyEtikettMaker;
+import models.Globals;
+import models.Node;
+
+public class Enrich {
+	private static final String alternateName =
+			"http://www.geonames.org/ontology#alternateName";
+	private static final String first =
+			"http://www.w3.org/1999/02/22-rdf-syntax-ns#first";
+	private static final String rest =
+			"http://www.w3.org/1999/02/22-rdf-syntax-ns#rest";
+	private static final String nil =
+			"http://www.w3.org/1999/02/22-rdf-syntax-ns#nil";
+
+	private static final String PREF_LABEL =
+			"http://www.w3.org/2004/02/skos/core#prefLabel";
+
+	public static String enrichMetadata2(Node node) {
+		try {
+			play.Logger.info("Enrich 2 " + node.getPid());
+			String metadata = node.getMetadata2();
+			if (metadata == null || metadata.isEmpty()) {
+				play.Logger.info("No metadata2 to enrich " + node.getPid());
+				return "No metadata2 to enrich " + node.getPid();
+			}
+			List<Statement> enrichStatements = new ArrayList<>();
+			enrichAll(node, metadata, enrichStatements);
+			metadata = RdfUtils.replaceTriples(enrichStatements, metadata);
+			new Modify().updateMetadata2(node, metadata);
+		} catch (Exception e) {
+			play.Logger.debug("", e);
+			return "Enrichment of " + node.getPid() + " partially failed !\n"
+					+ e.getMessage();
+		}
+		return "Enrichment of " + node.getPid() + " succeeded!";
+	}
+
+	public static String enrichMetadata(Node node) {
+		try {
+			play.Logger.info("Enrich " + node.getPid());
+			String metadata = node.getMetadata1();
+			if (metadata == null || metadata.isEmpty()) {
+				play.Logger.info("Not metadata to enrich " + node.getPid());
+				return "Not metadata to enrich " + node.getPid();
+			}
+			List<Statement> enrichStatements = new ArrayList<>();
+			enrichAll(node, metadata, enrichStatements);
+			metadata = RdfUtils.replaceTriples(enrichStatements, metadata);
+			new Modify().updateMetadata1(node, metadata);
+
+		} catch (Exception e) {
+			play.Logger.warn(e.getMessage());
+			play.Logger.debug("", e);
+			return "Enrichment of " + node.getPid() + " partially failed !\n"
+					+ e.getMessage();
+		}
+		return "Enrichment of " + node.getPid() + " succeeded!";
+	}
+
+	private static void enrichAll(Node node, String metadata,
+			List<Statement> enrichStatements) {
+		enrichGnd(node, metadata, enrichStatements);
+
+		enrichGeonames(node, metadata, enrichStatements);
+
+		enrichOsm(node, metadata, enrichStatements);
+
+		enrichOrcid(node, metadata, enrichStatements);
+
+		enrichAdhocIds(node, metadata, enrichStatements);
+
+		enrichAgrovoc(node, metadata, enrichStatements);
+
+		enrichInstitution(node, enrichStatements);
+
+		enrichIsPartOf(node, metadata, enrichStatements);
+
+		enrichSeries(node, metadata, enrichStatements);
+
+		enrichMultivolumeWork(node, metadata, enrichStatements);
+
+		enrichLanguage(node, metadata, enrichStatements);
+
+		enrichRecordingLocation(node, metadata, enrichStatements);
+
+		enrichCollectionOne(node, metadata, enrichStatements);
+
+		enrichCollectionTwo(node, metadata, enrichStatements);
+
+		enrichContainedIn(node, metadata, enrichStatements);
+
+		enrichFundingId(node, metadata, enrichStatements);
+	}
+
+	private static void enrichFundingId(Node node, String metadata,
+			List<Statement> enrichStatements) {
+		try {
+			play.Logger.debug("ENRICH FUNDING!-----------------------------");
+			enrichStatements
+					.addAll(find(node, metadata, "http://hbz-nrw.de/regal#fundingId"));
+		} catch (Exception e) {
+			play.Logger.debug("", e);
+		}
+	}
+
+	private static void enrichContainedIn(Node node, String metadata,
+			List<Statement> enrichStatements) {
+		try {
+			List<Statement> containedIn =
+					find(node, metadata, "http://purl.org/lobid/lv#containedIn");
+			enrichStatements.addAll(containedIn);
+		} catch (Exception e) {
+			play.Logger.debug("", e);
+		}
+	}
+
+	private static void enrichCollectionTwo(Node node, String metadata,
+			List<Statement> enrichStatements) {
+		try {
+			List<Statement> collectionTwo =
+					find(node, metadata, "info:regal/zettel/collectionTwo");
+			enrichStatements.addAll(collectionTwo);
+		} catch (Exception e) {
+			play.Logger.debug("", e);
+		}
+	}
+
+	private static void enrichCollectionOne(Node node, String metadata,
+			List<Statement> enrichStatements) {
+		List<Statement> collectionOne =
+				find(node, metadata, "info:regal/zettel/collectionOne");
+		enrichStatements.addAll(collectionOne);
+	}
+
+	private static void enrichRecordingLocation(Node node, String metadata,
+			List<Statement> enrichStatements) {
+		try {
+			play.Logger.info("Enrich " + node.getPid() + " with recordingLocation.");
+			List<Statement> recordingLocation =
+					find(node, metadata, "http://hbz-nrw.de/regal#recordingLocation");
+			enrichStatements.addAll(recordingLocation);
+		} catch (Exception e) {
+			play.Logger.debug("", e);
+		}
+	}
+
+	private static void enrichLanguage(Node node, String metadata,
+			List<Statement> enrichStatements) {
+		try {
+			play.Logger.info("Enrich " + node.getPid() + " with language.");
+			List<Statement> language =
+					find(node, metadata, "http://purl.org/dc/terms/language");
+			enrichStatements.addAll(language);
+		} catch (Exception e) {
+			play.Logger.debug("", e);
+		}
+	}
+
+	private static void enrichMultivolumeWork(Node node, String metadata,
+			List<Statement> enrichStatements) {
+		try {
+			play.Logger.info("Enrich " + node.getPid() + " with multiVolumeWork.");
+			List<Statement> multiVolumeWork =
+					find(node, metadata, "http://purl.org/lobid/lv#multiVolumeWork");
+			enrichStatements.addAll(multiVolumeWork);
+		} catch (Exception e) {
+			play.Logger.debug("", e);
+		}
+	}
+
+	private static void enrichSeries(Node node, String metadata,
+			List<Statement> enrichStatements) {
+		try {
+			play.Logger.info("Enrich " + node.getPid() + " with inSeries.");
+			List<Statement> series =
+					find(node, metadata, "http://purl.org/lobid/lv#series");
+			enrichStatements.addAll(series);
+		} catch (Exception e) {
+			play.Logger.debug("", e);
+		}
+	}
+
+	private static void enrichIsPartOf(Node node, String metadata,
+			List<Statement> enrichStatements) {
+		try {
+			play.Logger.info("Enrich " + node.getPid() + " with parent.");
+			List<Statement> catalogParents =
+					find(node, metadata, "http://purl.org/dc/terms/isPartOf");
+			enrichStatements.addAll(catalogParents);
+		} catch (Exception e) {
+			play.Logger.debug("", e);
+		}
+	}
+
+	private static void enrichInstitution(Node node,
+			List<Statement> enrichStatements) {
+		try {
+			play.Logger.info("Enrich " + node.getPid() + " with institution.");
+			List<Statement> institutions = findInstitution(node);
+			enrichStatements.addAll(institutions);
+		} catch (Exception e) {
+			play.Logger.debug("", e);
+		}
+	}
+
+	private static void enrichAgrovoc(Node node, String metadata,
+			List<Statement> enrichStatements) {
+		try {
+			play.Logger.info("Enrich " + node.getPid() + " with agrovoc.");
+			List<String> agrovocIds = findAllAgrovocIds(metadata);
+			for (String uri : agrovocIds) {
+				enrichStatements.addAll(getAgrovocStatements(uri));
+			}
+		} catch (Exception e) {
+			play.Logger.debug("", e);
+		}
+	}
+
+	private static void enrichAdhocIds(Node node, String metadata,
+			List<Statement> enrichStatements) {
+		try {
+			play.Logger.info("Enrich " + node.getPid() + " with adhoc keys.");
+			List<String> adhocIds = findAllAdhocIds(metadata);
+			for (String uri : adhocIds) {
+				enrichStatements.addAll(getAdhocStatements(uri));
+			}
+		} catch (Exception e) {
+			play.Logger.debug("", e);
+		}
+	}
+
+	private static void enrichOrcid(Node node, String metadata,
+			List<Statement> enrichStatements) {
+		try {
+			play.Logger.info("Enrich " + node.getPid() + " with orcid.");
+			List<String> orcidIds = findAllOrcidIds(metadata);
+			for (String uri : orcidIds) {
+				enrichStatements.addAll(getOrcidStatements(uri));
+			}
+		} catch (Exception e) {
+			play.Logger.debug("", e);
+		}
+	}
+
+	private static void enrichOsm(Node node, String metadata,
+			List<Statement> enrichStatements) {
+		try {
+			play.Logger.info("Enrich " + node.getPid() + " with openstreetmap.");
+			List<String> osmIds = findAllOsmIds(metadata);
+			for (String uri : osmIds) {
+				enrichStatements.addAll(getOsmStatements(uri));
+			}
+		} catch (Exception e) {
+			play.Logger.debug("", e);
+		}
+	}
+
+	private static void enrichGeonames(Node node, String metadata,
+			List<Statement> enrichStatements) {
+		try {
+			play.Logger.info("Enrich " + node.getPid() + " with geonames.");
+			List<String> geoNameIds = findAllGeonameIds(metadata);
+			for (String uri : geoNameIds) {
+				enrichStatements.addAll(getGeonamesStatements(uri));
+			}
+		} catch (Exception e) {
+			play.Logger.debug("", e);
+		}
+	}
+
+	private static void enrichGnd(Node node, String metadata,
+			List<Statement> enrichStatements) {
+		try {
+			play.Logger.info("Enrich " + node.getPid() + " with gnd.");
+			List<String> gndIds = findAllGndIds(metadata);
+			for (String uri : gndIds) {
+				enrichStatements.addAll(getStatements(uri));
+			}
+		} catch (Exception e) {
+			play.Logger.debug("", e);
+		}
+	}
+
+	private static List<Statement> find(Node node, String metadata, String pred) {
+		List<Statement> result = new ArrayList<Statement>();
+		// getIsPartOf
+
+		List<String> statements = RdfUtils.findRdfObjects(node.getPid(), pred,
+				metadata, RDFFormat.NTRIPLES);
+		for (String p : statements) {
+			ValueFactory v = RdfUtils.valueFactory;
+			String label = getEtikett(p);
+			Statement st = v.createStatement(v.createIRI(p), v.createIRI(PREF_LABEL),
+					v.createLiteral(Normalizer.normalize(label, Normalizer.Form.NFKC)));
+			result.add(st);
+			play.Logger.debug(
+					"Found on " + pred + " -> object: " + st.getObject().stringValue()
+							+ " -> subject: " + st.getSubject().stringValue());
+		}
+		return result;
+	}
+
+	private static String getEtikett(String p) {
+		String prefLabel = MyEtikettMaker.getLabelFromEtikettWs(p);
+		return prefLabel;
+	}
+
+	private static List<Statement> findInstitution(Node node) {
+		List<Statement> result = new ArrayList<Statement>();
+		try {
+			String alephid = new Read().getIdOfParallelEdition(node);
+			String uri = Globals.lobidHbz01 + alephid + "/about?format=source";
+			play.Logger.info("GET " + uri);
+			try (InputStream in =
+					RdfUtils.urlToInputStream(new URL(uri), "application/xml")) {
+				String gndEndpoint = "http://d-nb.info/gnd/";
+				List<Element> institutionHack = XmlUtils.getElements(
+						"//datafield[@tag='078' and @ind1='r' and @ind2='1']/subfield", in,
+						null);
+
+				for (Element el : institutionHack) {
+					String marker = el.getTextContent();
+					if (!marker.contains("ellinet"))
+						continue;
+					if (!marker.contains("GND"))
+						continue;
+					String gndId = gndEndpoint
+							+ marker.replaceFirst(".*ellinet.*GND:.*\\([^)]*\\)", "");
+					if (gndId.endsWith("16269969-4")) {
+						gndId = gndEndpoint + "2006655-7";
+					}
+					play.Logger.trace("Add data from " + gndId);
+					ValueFactory v = RdfUtils.valueFactory;
+					Statement link = v.createStatement(v.createIRI(node.getPid()),
+							v.createIRI("http://dbpedia.org/ontology/institution"),
+							v.createIRI(gndId));
+					result.add(link);
+					result.addAll(getStatements(gndId));
+				}
+
+			}
+		} catch (Exception e) {
+			play.Logger.info("No institution found for " + node.getPid());
+
+		}
+		play.Logger.info("ADD to collection: " + result);
+		return result;
+	}
+
+	private static List<Statement> getStatements(String uri) {
+		play.Logger.info("GET " + uri);
+		List<Statement> filteredStatements = new ArrayList<Statement>();
+		try {
+			for (Statement s : RdfUtils.readRdfToGraph(new URL(uri + "/about/lds"),
+					RDFFormat.RDFXML, "application/rdf+xml")) {
+				boolean isLiteral = s.getObject() instanceof Literal;
+				if (!(s.getSubject() instanceof BNode)) {
+					if (isLiteral) {
+						ValueFactory v = RdfUtils.valueFactory;
+
+						play.Logger.trace("Get data from " + uri);
+						Statement newS = v.createStatement(v.createIRI(uri),
+								s.getPredicate(), v.createLiteral(Normalizer.normalize(
+										s.getObject().stringValue(), Normalizer.Form.NFKC)));
+						filteredStatements.add(newS);
+					}
+				}
+			}
+		} catch (Exception e) {
+			play.Logger.warn("Not able to get data from" + uri, e);
+		}
+		return filteredStatements;
+	}
+
+	private static List<Statement> getOrcidStatements(String uri) {
+		play.Logger.trace("GET " + uri);
+		List<Statement> filteredStatements = new ArrayList<Statement>();
+		try (InputStream in =
+				RdfUtils.urlToInputStream(new URL(uri), "application/json")) {
+			String str =
+					CharStreams.toString(new InputStreamReader(in, Charsets.UTF_8));
+			JsonNode hit = new ObjectMapper().readValue(str, JsonNode.class);
+			String label = hit.at("/person/name/family-name/value").asText() + ", "
+					+ hit.at("/person/name/given-names/value").asText();
+			ValueFactory v = RdfUtils.valueFactory;
+			Literal object =
+					v.createLiteral(Normalizer.normalize(label, Normalizer.Form.NFKC));
+			Statement newS =
+					v.createStatement(v.createIRI(uri), v.createIRI(PREF_LABEL), object);
+			play.Logger.trace("Get data from " + uri + " " + newS);
+			filteredStatements.add(newS);
+		} catch (Exception e) {
+			play.Logger.warn("", e);
+		}
+		return filteredStatements;
+	}
+
+	private static List<Statement> getAdhocStatements(String uri) {
+		play.Logger.info("GET " + uri);
+		List<Statement> filteredStatements = new ArrayList<Statement>();
+		try {
+			for (Statement s : RdfUtils.readRdfToGraph(new URL(uri), RDFFormat.RDFXML,
+					"application/rdf+xml")) {
+				boolean isLiteral = s.getObject() instanceof Literal;
+				if (!(s.getSubject() instanceof BNode)) {
+					if (isLiteral) {
+						ValueFactory v = RdfUtils.valueFactory;
+
+						play.Logger.trace("Get data from " + uri);
+						Statement newS = v.createStatement(v.createIRI(uri),
+								s.getPredicate(), v.createLiteral(Normalizer.normalize(
+										s.getObject().stringValue(), Normalizer.Form.NFKC)));
+						filteredStatements.add(newS);
+					}
+				}
+			}
+		} catch (Exception e) {
+			play.Logger.warn("Not able to get data from" + uri, e);
+		}
+		return filteredStatements;
+	}
+
+	private static List<Statement> getOsmStatements(String uri) {
+		play.Logger.trace("GET " + uri);
+		List<Statement> filteredStatements = new ArrayList<Statement>();
+		try {
+			URL url = new URL(uri);
+			Map<String, String> map = new LinkedHashMap<String, String>();
+			String query = url.getQuery();
+			for (String pair : query.split("&")) {
+				String[] keyValue = pair.split("=");
+				int idx = pair.indexOf("=");
+				map.put(URLDecoder.decode(keyValue[0], "UTF-8"),
+						URLDecoder.decode(keyValue[1], "UTF-8"));
+			}
+			ValueFactory v = RdfUtils.valueFactory;
+			Literal object = v.createLiteral(Normalizer.normalize(
+					map.get("mlat") + "," + map.get("mlon"), Normalizer.Form.NFKC));
+			Statement newS =
+					v.createStatement(v.createIRI(uri), v.createIRI(PREF_LABEL), object);
+			play.Logger.trace("Get data from " + uri + " " + newS);
+			filteredStatements.add(newS);
+		} catch (Exception e) {
+			play.Logger.warn(e.getMessage());
+			play.Logger.debug("", e);
+		}
+		return filteredStatements;
+	}
+
+	private static List<Statement> getGeonamesStatements(String uri) {
+		play.Logger.trace("GET " + uri);
+		ValueFactory vf = SimpleValueFactory.getInstance();
+		List<Statement> filteredStatements = new ArrayList<Statement>();
+		List<Literal> alternateNames = new ArrayList<Literal>();
+		try {
+			for (Statement s : RdfUtils.readRdfToGraph(new URL(uri + "/about.rdf"),
+					RDFFormat.RDFXML, "application/rdf+xml")) {
+				boolean isLiteral = s.getObject() instanceof Literal;
+				if (!(s.getSubject() instanceof BNode)) {
+					if (isLiteral) {
+						Literal l = (Literal) s.getObject();
+						Literal object = vf.createLiteral(Normalizer
+								.normalize(s.getObject().stringValue(), Normalizer.Form.NFKC),
+								l.getLanguage().get());
+						Statement newS =
+								vf.createStatement(vf.createIRI(uri), s.getPredicate(), object);
+						play.Logger.trace("Get data from " + uri + " " + newS);
+
+						if (alternateName.equals(s.getPredicate().stringValue())) {
+							newS = vf.createStatement(vf.createIRI(uri), vf.createIRI(
+									s.getPredicate().stringValue() + "_" + object.getLanguage()),
+									object);
+						}
+						filteredStatements.add(newS);
+					}
+				}
+			}
+		} catch (Exception e) {
+			play.Logger.warn("Not able to get data from" + uri);
+		}
+
+		return filteredStatements;
+	}
+
+	private static List<Statement> getAgrovocStatements(String uri) {
+		play.Logger.trace("GET " + uri);
+		ValueFactory vf = SimpleValueFactory.getInstance();
+		List<Statement> filteredStatements = new ArrayList<Statement>();
+		List<Literal> prefLabel = new ArrayList<Literal>();
+		try {
+			for (Statement s : RdfUtils.readRdfToGraph(new URL(uri), RDFFormat.RDFXML,
+					"application/rdf+xml")) {
+				boolean isLiteral = s.getObject() instanceof Literal;
+				if (!(s.getSubject() instanceof BNode)) {
+					if (isLiteral) {
+						Literal l = (Literal) s.getObject();
+						Literal object = vf.createLiteral(Normalizer
+								.normalize(s.getObject().stringValue(), Normalizer.Form.NFKC),
+								l.getLanguage().get());
+						Statement newS =
+								vf.createStatement(vf.createIRI(uri), s.getPredicate(), object);
+						play.Logger.trace("Get data from " + uri + " " + newS);
+
+						if (PREF_LABEL.equals(s.getPredicate().stringValue())) {
+							if ("de".equals(object.getLanguage())) {
+								newS = vf.createStatement(vf.createIRI(uri), s.getPredicate(),
+										object);
+								filteredStatements.add(newS);
+							}
+							newS = vf.createStatement(vf.createIRI(uri), vf.createIRI(
+									s.getPredicate().stringValue() + "_" + object.getLanguage()),
+									object);
+						}
+						filteredStatements.add(newS);
+					}
+				}
+			}
+		} catch (Exception e) {
+			play.Logger.warn("Not able to get data from" + uri);
+		}
+
+		return filteredStatements;
+	}
+
+	private static List<Statement> getListAsStatements(List<Literal> list,
+			String uri, String predicate) {
+		List<Statement> listStatements = new ArrayList<Statement>();
+		ValueFactory vf = SimpleValueFactory.getInstance();
+		BNode head = vf.createBNode();
+		Statement newS =
+				vf.createStatement(vf.createIRI(uri), vf.createIRI(predicate), head);
+		listStatements.add(newS);
+
+		Resource cur = head;
+		for (Literal l : list) {
+			BNode r = vf.createBNode();
+			Statement linkToRest = vf.createStatement(cur, vf.createIRI(rest), r);
+			Statement linkToValue = vf.createStatement(cur, vf.createIRI(first), l);
+			cur = r;
+			listStatements.add(linkToRest);
+			listStatements.add(linkToValue);
+		}
+		Statement endOfList = listStatements.get(listStatements.size() - 1);
+		listStatements.remove(listStatements.size() - 1);
+		Statement linkToNill = vf.createStatement(endOfList.getSubject(),
+				vf.createIRI(rest), vf.createIRI(nil));
+		listStatements.add(linkToNill);
+		return listStatements;
+	}
+
+	private static List<String> findAllGndIds(String metadata) {
+		HashMap<String, String> result = new HashMap<String, String>();
+		Matcher m = Pattern.compile("http://d-nb.info/gnd/[1234567890-]*[A-Z]*")
+				.matcher(metadata);
+		while (m.find()) {
+			String id = m.group();
+			result.put(id, id);
+		}
+		return new Vector<String>(result.keySet());
+	}
+
+	private static List<String> findAllGeonameIds(String metadata) {
+		HashMap<String, String> result = new HashMap<String, String>();
+		Matcher m = Pattern.compile("http://www.geonames.org/[1234567890-]*")
+				.matcher(metadata);
+		while (m.find()) {
+			String id = m.group();
+			result.put(id, id);
+		}
+		return new Vector<String>(result.keySet());
+	}
+
+	private static List<String> findAllOsmIds(String metadata) {
+		HashMap<String, String> result = new HashMap<String, String>();
+		Matcher m =
+				Pattern.compile("http://www.openstreetmap.org/[^>]*").matcher(metadata);
+		while (m.find()) {
+			String id = m.group();
+			result.put(id, id);
+		}
+		return new Vector<String>(result.keySet());
+	}
+
+	private static List<String> findAllOrcidIds(String metadata) {
+		HashMap<String, String> result = new HashMap<>();
+		Matcher m = Pattern.compile("https?://orcid.org/[^>]*").matcher(metadata);
+		while (m.find()) {
+			String id = m.group();
+			result.put(id, id);
+		}
+		return new Vector<String>(result.keySet());
+	}
+
+	private static List<String> findAllAdhocIds(String metadata) {
+		HashMap<String, String> result = new HashMap<>();
+		Matcher m =
+				Pattern.compile(Globals.protocol + Globals.server + "/adhoc/[^>]*")
+						.matcher(metadata);
+		while (m.find()) {
+			String id = m.group();
+			result.put(id, id);
+		}
+		return new Vector<String>(result.keySet());
+	}
+
+	private static List<String> findAllAgrovocIds(String metadata) {
+		HashMap<String, String> result = new HashMap<>();
+		Matcher m = Pattern.compile("http://aims.fao.org/aos/agrovoc/[^>]*")
+				.matcher(metadata);
+		while (m.find()) {
+			String id = m.group();
+			result.put(id, id);
+		}
+		return new Vector<String>(result.keySet());
+	}
+
+}

--- a/app/actions/Modify.java
+++ b/app/actions/Modify.java
@@ -854,6 +854,10 @@ public class Modify extends RegalAction {
 					find(node, metadata, "info:regal/zettel/collectionOne");
 			enrichStatements.addAll(collectionOne);
 
+			List<Statement> collectionTwo =
+					find(node, metadata, "info:regal/zettel/collectionTwo");
+			enrichStatements.addAll(collectionTwo);
+
 			List<Statement> containedIn =
 					find(node, metadata, "http://purl.org/lobid/lv#containedIn");
 			enrichStatements.addAll(containedIn);
@@ -948,6 +952,10 @@ public class Modify extends RegalAction {
 			List<Statement> collectionOne =
 					find(node, metadata, "info:regal/zettel/collectionOne");
 			enrichStatements.addAll(collectionOne);
+
+			List<Statement> collectionTwo =
+					find(node, metadata, "info:regal/zettel/collectionTwo");
+			enrichStatements.addAll(collectionTwo);
 
 			List<Statement> containedIn =
 					find(node, metadata, "http://purl.org/lobid/lv#containedIn");

--- a/app/actions/Modify.java
+++ b/app/actions/Modify.java
@@ -862,9 +862,9 @@ public class Modify extends RegalAction {
 					find(node, metadata, "http://purl.org/lobid/lv#containedIn");
 			enrichStatements.addAll(containedIn);
 
-			List<Statement> fundingId =
-					find(node, metadata, "http://hbz-nrw.de/regal#fundingId");
-			enrichStatements.addAll(fundingId);
+			List<Statement> fundingJoined =
+					find(node, metadata, "http://hbz-nrw.de/regal#fundingJoined");
+			enrichStatements.addAll(fundingJoined);
 
 			metadata = RdfUtils.replaceTriples(enrichStatements, metadata);
 
@@ -965,9 +965,9 @@ public class Modify extends RegalAction {
 					find(node, metadata, "http://purl.org/lobid/lv#containedIn");
 			enrichStatements.addAll(containedIn);
 
-			List<Statement> fundingId =
-					find(node, metadata, "http://hbz-nrw.de/regal#fundingId");
-			enrichStatements.addAll(fundingId);
+			List<Statement> fundingJoined =
+					find(node, metadata, "http://hbz-nrw.de/regal#fundingJoined");
+			enrichStatements.addAll(fundingJoined);
 
 			metadata = RdfUtils.replaceTriples(enrichStatements, metadata);
 

--- a/app/actions/Modify.java
+++ b/app/actions/Modify.java
@@ -862,6 +862,10 @@ public class Modify extends RegalAction {
 					find(node, metadata, "http://purl.org/lobid/lv#containedIn");
 			enrichStatements.addAll(containedIn);
 
+			List<Statement> fundingId =
+					find(node, metadata, "http://hbz-nrw.de/regal#fundingId");
+			enrichStatements.addAll(fundingId);
+
 			metadata = RdfUtils.replaceTriples(enrichStatements, metadata);
 
 			updateMetadata1(node, metadata);
@@ -960,6 +964,10 @@ public class Modify extends RegalAction {
 			List<Statement> containedIn =
 					find(node, metadata, "http://purl.org/lobid/lv#containedIn");
 			enrichStatements.addAll(containedIn);
+
+			List<Statement> fundingId =
+					find(node, metadata, "http://hbz-nrw.de/regal#fundingId");
+			enrichStatements.addAll(fundingId);
 
 			metadata = RdfUtils.replaceTriples(enrichStatements, metadata);
 

--- a/app/actions/Modify.java
+++ b/app/actions/Modify.java
@@ -1015,9 +1015,9 @@ public class Modify extends RegalAction {
 		}
 	}
 
-	public String lobidify(Node node, String alephid) {
+	public String lobidify1(Node node, String alephid) {
 		updateMetadata1(node, getLobidDataAsNtripleString(node, alephid));
-		String enrichMessage = Enrich.enrichMetadata(node);
+		String enrichMessage = Enrich.enrichMetadata1(node);
 		return enrichMessage;
 	}
 

--- a/app/controllers/MyUtils.java
+++ b/app/controllers/MyUtils.java
@@ -282,7 +282,7 @@ public class MyUtils extends MyController {
 									+ conf.getUrl()
 									+ "\"^^<http://www.w3.org/2001/XMLSchema#string> .");
 				} else {
-					new actions.Modify().lobidify(webpage, ht);
+					new actions.Modify().lobidify2(webpage, ht);
 				}
 				play.Logger.info("Import Webpage: " + webpage.getPid());
 			}

--- a/app/controllers/Resource.java
+++ b/app/controllers/Resource.java
@@ -202,6 +202,7 @@ public class Resource extends MyController {
 				Map<String, Object> rdf = node.getLd2();
 				rdf.put("@context", Globals.profile.getContext().get("@context"));
 				String jsonString = JsonUtil.mapper().writeValueAsString(rdf);
+
 				if (request().accepts("application/rdf+xml")) {
 					result = RdfUtils.readRdfToString(
 							new ByteArrayInputStream(jsonString.getBytes("utf-8")),

--- a/app/controllers/Resource.java
+++ b/app/controllers/Resource.java
@@ -53,6 +53,7 @@ import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.core.util.JsonUtil;
 
 import actions.BulkAction;
+import actions.Enrich;
 import archive.fedora.RdfUtils;
 import authenticate.BasicAuth;
 import helper.HttpArchiveException;
@@ -935,7 +936,7 @@ public class Resource extends MyController {
 	public static Promise<Result> enrichMetadata(@PathParam("pid") String pid) {
 		return new ModifyAction().call(pid, userId -> {
 			Node node = readNodeOrNull(pid);
-			String result = modify.enrichMetadata(node);
+			String result = Enrich.enrichMetadata1(node);
 			return JsonMessage(new Message(json(result)));
 		});
 	}
@@ -944,7 +945,7 @@ public class Resource extends MyController {
 	public static Promise<Result> enrichMetadata2(@PathParam("pid") String pid) {
 		return new ModifyAction().call(pid, userId -> {
 			Node node = readNodeOrNull(pid);
-			String result = modify.enrichMetadata(node);
+			String result = Enrich.enrichMetadata2(node);
 			return JsonMessage(new Message(json(result)));
 		});
 	}
@@ -1234,7 +1235,7 @@ public class Resource extends MyController {
 				} else {
 					node = create.createResource(namespace, object);
 				}
-				String message = modify.lobidify(node, alephId);
+				String message = modify.lobidify2(node, alephId);
 				flash("message", message);
 				return redirect(routes.Resource.listResource(node.getPid(), null));
 			} catch (Exception e) {

--- a/app/de/hbz/lobid/helper/JsonConverter.java
+++ b/app/de/hbz/lobid/helper/JsonConverter.java
@@ -158,16 +158,7 @@ public class JsonConverter {
 								((BNode) s.getObject()).getID());
 					}
 				} else {
-					if (s.getPredicate().stringValue().equals(RDF_TYPE)) {
-						try {
-							addLiteralToJsonResult(jsonResult, key,
-									etikette.getEtikett(s.getObject().stringValue()).name);
-						} catch (Exception ex) {
-							logger.info("", ex);
-						}
-					} else {
-						addObjectToJsonResult(jsonResult, key, s.getObject().stringValue());
-					}
+					addObjectToJsonResult(jsonResult, key, s.getObject().stringValue());
 				}
 			}
 		} catch (Exception exc) {
@@ -181,18 +172,8 @@ public class JsonConverter {
 		if (s.getObject() instanceof org.eclipse.rdf4j.model.Literal) {
 			addLiteralToJsonResult(jsonResult, key, s.getObject().stringValue());
 		} else {
-
-			if (s.getPredicate().stringValue().equals(RDF_TYPE)) {
-				try {
-					addLiteralToJsonResult(jsonResult, key,
-							etikette.getEtikett(s.getObject().stringValue()).name);
-				} catch (Exception ex) {
-					logger.info("", ex);
-				}
-			} else {
-				logger.trace("Will not follow path to " + s.getObject().toString()
-						+ " ! I have already visited this object!");
-			}
+			logger.trace("Will not follow path to " + s.getObject().toString()
+					+ " ! I have already visited this object!");
 		}
 
 	}

--- a/app/de/hbz/lobid/helper/LobidTypes.java
+++ b/app/de/hbz/lobid/helper/LobidTypes.java
@@ -1,0 +1,88 @@
+package de.hbz.lobid.helper;
+
+public class LobidTypes {
+	public static final String EditedVolume =
+			"http://purl.org/lobid/lv#EditedVolume";
+
+	public static final String PublicationEvent =
+			"http://schema.org/PublicationEvent";
+
+	public static final String Report = "http://purl.org/ontology/bibo/Report";
+
+	public static final String OfficialPublication =
+			"http://purl.org/lobid/lv#OfficialPublication";
+
+	public static final String Periodical =
+			"http://purl.org/ontology/bibo/Periodical";
+
+	public static final String Biography = "http://purl.org/lobid/lv#Biography";
+
+	public static final String Standard =
+			"http://purl.org/ontology/bibo/Standard";
+
+	public static final String SoftwareApplication =
+			"http://schema.org/SoftwareApplication";
+
+	public static final String ArchivedWebPage =
+			"http://purl.org/lobid/lv#ArchivedWebPage";
+
+	public static final String Thesis = "http://purl.org/ontology/bibo/Thesis";
+
+	public static final String Legislation =
+			"http://purl.org/lobid/lv#Legislation";
+
+	public static final String Proceedings =
+			"http://purl.org/ontology/bibo/Proceedings";
+
+	public static final String Miscellaneous =
+			"http://purl.org/lobid/lv#Miscellaneous";
+
+	public static final String Bibliography =
+			"http://purl.org/lobid/lv#Bibliography";
+
+	public static final String Statistics = "http://purl.org/lobid/lv#Statistics";
+
+	public static final String Schoolbook = "http://purl.org/lobid/lv#Schoolbook";
+
+	public static final String PublishedScore =
+			"http://purl.org/ontology/mo/PublishedScore";
+
+	public static final String Festschrift =
+			"http://purl.org/lobid/lv#Festschrift";
+
+	public static final String ConferenceOrEvent =
+			"http://d-nb.info/standards/elementset/gnd#ConferenceOrEvent";
+
+	public static final String Article = "http://purl.org/ontology/bibo/Article";
+
+	public static final String Map = "http://purl.org/ontology/bibo/Map";
+
+	public static final String Person =
+			"http://d-nb.info/standards/elementset/gnd#Person";
+
+	public static final String MultiVolumeBook =
+			"http://purl.org/ontology/bibo/MultiVolumeBook";
+
+	public static final String Newspaper =
+			"http://purl.org/ontology/bibo/Newspaper";
+
+	public static final String Game = "http://schema.org/Game";
+
+	public static final String Book = "http://purl.org/ontology/bibo/Book";
+
+	public static final String Combination =
+			"http://iflastandards.info/ns/isbd/terms/mediatype/T1008";
+
+	public static final String Work =
+			"http://d-nb.info/standards/elementset/gnd#Work";
+
+	public static final String Image = "http://purl.org/ontology/bibo/Image";
+
+	public static final String ReferenceSource =
+			"http://purl.org/ontology/bibo/ReferenceSource";
+
+	public static final String PlaceOrGeographicName =
+			"http://d-nb.info/standards/elementset/gnd#PlaceOrGeographicName";
+
+	public static final String Chapter = "http://purl.org/ontology/bibo/Chapter";
+}

--- a/app/helper/DataciteMapper.java
+++ b/app/helper/DataciteMapper.java
@@ -62,14 +62,20 @@ public class DataciteMapper {
 	}
 
 	private static void addResourceType(JsonNode ld, DataciteRecord rec) {
-		rec.type = ld.at("/rdftype/0/prefLabel").asText();
-		if ("Abschlussarbeit".equals(rec.type)) {
-			rec.type = "Hochschulschrift";
-		} else if ("Statistics".equals(rec.type)) {
-			rec.type = "Statistik";
-		} else if ("Leitlinien / Normschriften".equals(rec.type)) {
-			rec.type = "Leitlinie";
-		}
+		rec.type = "";
+		ld.at("/rdftype/").forEach(curType -> {
+			String label = curType.at("prefLabel").asText();
+			if ("Abschlussarbeit".equals(label)) {
+				rec.type = "Hochschulschrift";
+			} else if ("Statistics".equals(label)) {
+				rec.type = "Statistik";
+			} else if ("Leitlinien / Normschriften".equals(label)) {
+				rec.type = "Leitlinie";
+			} else {
+				rec.type = label;
+			}
+		});
+
 	}
 
 	private static void addResourceTypeGeneral(JsonNode ld, DataciteRecord rec) {

--- a/app/helper/DataciteMapper.java
+++ b/app/helper/DataciteMapper.java
@@ -63,8 +63,10 @@ public class DataciteMapper {
 
 	private static void addResourceType(JsonNode ld, DataciteRecord rec) {
 		rec.type = "";
-		ld.at("/rdftype/").forEach(curType -> {
-			String label = curType.at("prefLabel").asText();
+		play.Logger.info("found type: " + rec.type);
+		ld.at("/rdftype").forEach(curType -> {
+			String label = curType.at("/prefLabel").asText();
+			play.Logger.info("found type: " + label);
 			if ("Abschlussarbeit".equals(label)) {
 				rec.type = "Hochschulschrift";
 			} else if ("Statistics".equals(label)) {
@@ -75,7 +77,6 @@ public class DataciteMapper {
 				rec.type = label;
 			}
 		});
-
 	}
 
 	private static void addResourceTypeGeneral(JsonNode ld, DataciteRecord rec) {

--- a/app/helper/DataciteMapper.java
+++ b/app/helper/DataciteMapper.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import de.hbz.lobid.helper.LobidTypes;
 import models.DataciteRecord;
 import models.Globals;
 import models.Pair;
@@ -65,13 +66,14 @@ public class DataciteMapper {
 		rec.type = "";
 		play.Logger.info("found type: " + rec.type);
 		ld.at("/rdftype").forEach(curType -> {
+			String lobidType = curType.at("/@id").asText();
 			String label = curType.at("/prefLabel").asText();
-			play.Logger.info("found type: " + label);
-			if ("Abschlussarbeit".equals(label)) {
+			play.Logger.info("found type: " + lobidType);
+			if (LobidTypes.Thesis.equals(lobidType)) {
 				rec.type = "Hochschulschrift";
-			} else if ("Statistics".equals(label)) {
+			} else if (LobidTypes.Statistics.equals(lobidType)) {
 				rec.type = "Statistik";
-			} else if ("Leitlinien / Normschriften".equals(label)) {
+			} else if (LobidTypes.Standard.equals(lobidType)) {
 				rec.type = "Leitlinie";
 			} else {
 				rec.type = label;

--- a/app/helper/JsonMapper.java
+++ b/app/helper/JsonMapper.java
@@ -407,22 +407,40 @@ public class JsonMapper {
 	}
 
 	private static void createJoinedFunding(Map<String, Object> rdf) {
-		List<String> funding = (List<String>) rdf.get("funding");
+
+		List<Map<String, Object>> fundingId =
+				(List<Map<String, Object>>) rdf.get("fundingId");
+		if (fundingId == null) {
+			fundingId = new ArrayList<>();
+		}
+		List<String> fundings = (List<String>) rdf.get("funding");
+		if (fundings != null) {
+			for (String funding : fundings) {
+				Map<String, Object> fundingJoinedMap = new LinkedHashMap<>();
+				fundingJoinedMap.put("@id", Globals.protocol + Globals.server
+						+ "/adhoc/uri/" + helper.MyURLEncoding.encode(funding));
+			}
+			// rdf.remove("funding");
+		}
 		List<String> fundingProgram = (List<String>) rdf.get("fundingProgram");
 		List<String> projectId = (List<String>) rdf.get("projectId");
 
 		List<Map<String, Object>> joinedFundings = new ArrayList<>();
-		if (funding == null)
+		if (fundingId.isEmpty())
 			return;
-		for (int i = 0; i < funding.size(); i++) {
-			play.Logger.info(funding.get(i));
+		for (int i = 0; i < fundingId.size(); i++) {
+			// play.Logger.info(fundingId.get(i));
 			Map<String, Object> f = new LinkedHashMap<>();
-			f.put("fundingJoined", funding.get(i));
+			Map<String, Object> fundingJoinedMap = new LinkedHashMap<>();
+			fundingJoinedMap.put("@id", fundingId.get(i).get("@id"));
+			fundingJoinedMap.put("prefLabel", fundingId.get(i).get("prefLabel"));
+			f.put("fundingJoined", fundingJoinedMap);
 			f.put("fundingProgramJoined", fundingProgram.get(i));
 			f.put("projectIdJoined", projectId.get(i));
 			joinedFundings.add(f);
 		}
 		rdf.put("joinedFunding", joinedFundings);
+		rdf.put("fundingId", fundingId);
 	}
 
 	private void addParts(Map<String, Object> rdf) {

--- a/app/helper/JsonMapper.java
+++ b/app/helper/JsonMapper.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -398,10 +399,29 @@ public class JsonMapper {
 			postProcess(rdf, "institution");
 			postProcessContribution(rdf);
 			postProcess(rdf, "creator");
+			createJoinedFunding(rdf);
 
 		} catch (Exception e) {
 			play.Logger.debug("", e);
 		}
+	}
+
+	private static void createJoinedFunding(Map<String, Object> rdf) {
+		List<String> funding = (List<String>) rdf.get("funding");
+		List<String> fundingProgram = (List<String>) rdf.get("fundingProgram");
+		List<String> projectId = (List<String>) rdf.get("projectId");
+
+		List<Map<String, Object>> joinedFundings = new ArrayList<>();
+
+		for (int i = 0; i < funding.size(); i++) {
+			play.Logger.info(funding.get(i));
+			Map<String, Object> f = new LinkedHashMap<>();
+			f.put("fundingJoined", funding.get(i));
+			f.put("fundingProgramJoined", fundingProgram.get(i));
+			f.put("projectIdJoined", projectId.get(i));
+			joinedFundings.add(f);
+		}
+		rdf.put("joinedFunding", joinedFundings);
 	}
 
 	private void addParts(Map<String, Object> rdf) {

--- a/app/helper/JsonMapper.java
+++ b/app/helper/JsonMapper.java
@@ -85,7 +85,7 @@ public class JsonMapper {
 	final static String size = "size";
 	final static String checksumValue = "checksumValue";
 	final static String generator = "generator";
-	final static String type = "rdftype";
+	final static String rdftype = "rdftype";
 	final static String checksum = "checksum";
 	final static String hasData = "hasData";
 	final static String fulltext_ocr = "fulltext-ocr";
@@ -112,7 +112,6 @@ public class JsonMapper {
 			"http://purl.org/ontology/bibo/AudioDocument",
 			"http://purl.org/ontology/bibo/Image",
 			"http://purl.org/ontology/bibo/Article",
-			"http://purl.org/ontology/bibo/Chapter",
 			"http://rdvocab.info/termList/RDACarrierType/1018",
 			"http://rdvocab.info/termList/RDACarrierType/1010",
 			"http://iflastandards.info/ns/isbd/terms/mediatype/T1002",
@@ -146,9 +145,9 @@ public class JsonMapper {
 			if (node == null)
 				throw new NullPointerException(
 						"JsonMapper can not work on node with value NULL!");
-			if (node.getMetadata1() == null)
-				throw new NullPointerException(
-						node.getPid() + " metadata stream is NULL!");
+			// if (node.getMetadata1() == null)
+			// throw new NullPointerException(
+			// node.getPid() + " metadata stream is NULL!");
 			if (node.getMetadata2() == null)
 				throw new NullPointerException(
 						node.getPid() + " metadata2 stream is NULL!");
@@ -267,7 +266,7 @@ public class JsonMapper {
 				Map<String, Object> checksumMap = new TreeMap<>();
 				checksumMap.put(checksumValue, node.getChecksum());
 				checksumMap.put(generator, "http://en.wikipedia.org/wiki/MD5");
-				checksumMap.put(type,
+				checksumMap.put(rdftype,
 						"http://downlode.org/Code/RDF/File_Properties/schema#Checksum");
 				hasDataMap.put(checksum, checksumMap);
 			}
@@ -296,8 +295,8 @@ public class JsonMapper {
 			return rdf;
 		} catch (Exception e) {
 			play.Logger
-					.warn(node.getPid() + " can not create JSON! " + e.getMessage());
-			play.Logger.debug("", e);
+					.trace(node.getPid() + " can not create JSON! " + e.getMessage());
+			play.Logger.trace("", e);
 		}
 		return null;
 	}
@@ -346,7 +345,7 @@ public class JsonMapper {
 				Map<String, Object> checksumMap = new HashMap<>();
 				checksumMap.put(checksumValue, node.getChecksum());
 				checksumMap.put(generator, "http://en.wikipedia.org/wiki/MD5");
-				checksumMap.put(type,
+				checksumMap.put(rdftype,
 						"http://downlode.org/Code/RDF/File_Properties/schema#Checksum");
 				hasDataMap.put(checksum, checksumMap);
 			}
@@ -360,12 +359,13 @@ public class JsonMapper {
 		try {
 			addCatalogLink(rdf);
 			if ("file".equals(rdf.get("contentType"))) {
-				rdf.put(type, Arrays.asList(new String[] { "File" }));
+				rdf.put(rdftype, Arrays.asList(new String[] { "File" }));
 			}
 
-			Collection<Map<String, Object>> t = getType(rdf);
+			Collection<Map<String, Object>> t =
+					getType(new ObjectMapper().valueToTree(rdf));
 			if (t != null && t.size() != 0)
-				rdf.put(type, t);
+				rdf.put(rdftype, t);
 
 			sortCreatorAndContributors(rdf);
 			postProcess(rdf, "subject");
@@ -412,7 +412,8 @@ public class JsonMapper {
 		List<String> projectId = (List<String>) rdf.get("projectId");
 
 		List<Map<String, Object>> joinedFundings = new ArrayList<>();
-
+		if (funding == null)
+			return;
 		for (int i = 0; i < funding.size(); i++) {
 			play.Logger.info(funding.get(i));
 			Map<String, Object> f = new LinkedHashMap<>();
@@ -448,6 +449,8 @@ public class JsonMapper {
 			List<Map<String, Object>> creator = new ArrayList<>();
 			Collection<Map<String, Object>> contributions =
 					(Collection<Map<String, Object>>) rdf.get("contribution");
+			if (contributions == null)
+				return;
 			for (Map<String, Object> contribution : contributions) {
 				Map<String, Object> agent =
 						((Collection<Map<String, Object>>) contribution.get("agent"))
@@ -473,18 +476,6 @@ public class JsonMapper {
 		} catch (Exception e) {
 			play.Logger.debug("Problem processing key contribution.agent", e);
 		}
-	}
-
-	private static boolean mediumArrayContains(Map<String, Object> rdf,
-			String key) {
-		boolean result = false;
-		JsonNode n = new ObjectMapper().valueToTree(rdf);
-		JsonNode mediumArray = n.at("/medium");
-		for (JsonNode item : mediumArray) {
-			if (key.equals(item.at("/@id").asText("no Value found")))
-				result = true;
-		}
-		return result;
 	}
 
 	private static void postProcess(Map<String, Object> m, String field) {
@@ -578,38 +569,6 @@ public class JsonMapper {
 		}
 	}
 
-	private static Collection<Map<String, Object>> getType(
-			Map<String, Object> rdf) {
-		Collection<Map<String, Object>> result = new ArrayList<>();
-
-		// Special case medium is video - override type
-		if (mediumArrayContains(rdf,
-				"http://rdaregistry.info/termList/RDAMediaType/1008")
-				|| mediumArrayContains(rdf,
-						"http://rdvocab.info/termList/RDACarrierType/1050")) {
-			String s = "http://rdaregistry.info/termList/RDAMediaType/1008";
-			Map<String, Object> tmap = new HashMap<>();
-			tmap.put(PREF_LABEL, Globals.profile.getEtikett(s).getLabel());
-			tmap.put(ID2, s);
-			result.add(tmap);
-			rdf.put(type, result);
-			return result;
-		}
-		Collection<String> types = (Collection<String>) rdf.get(type);
-		play.Logger.trace("Found types: " + types);
-		if (types != null) {
-			for (String t : types) {
-				if (t == null || "BibliographicResource".equals(t))
-					continue;
-				Map<String, Object> tmap = new HashMap<>();
-				tmap.put(PREF_LABEL, Globals.profile.getEtikett(t).getLabel());
-				tmap.put(ID2, t);
-				result.add(tmap);
-			}
-		}
-		return result;
-	}
-
 	private void addPartsToJsonMap(Map<String, Object> rdf) {
 		for (Link l : node.getPartsSorted()) {
 			if (l.getObjectLabel() == null || l.getObjectLabel().isEmpty())
@@ -665,9 +624,10 @@ public class JsonMapper {
 					+ RdfUtils.urlEncode(authorsId).replace("+", "%20"));
 			return creatorWithoutId;
 		}
-		if (m.get("creator") instanceof List) {
+
+		if (m.get("creator") instanceof List
+				&& ((List) m.get("creator")).get(0) instanceof String) {
 			Collection<String> creators = (Collection<String>) m.get("creator");
-			play.Logger.trace("" + creators.getClass());
 			for (String creator : creators) {
 				String currentId = creator;
 				play.Logger.trace(creator + " - " + currentId + " - " + authorsId);
@@ -861,7 +821,7 @@ public class JsonMapper {
 				Map<String, Object> checksumMap = new TreeMap<>();
 				checksumMap.put(checksumValue, node.getChecksum());
 				checksumMap.put(generator, "http://en.wikipedia.org/wiki/MD5");
-				checksumMap.put(type,
+				checksumMap.put(rdftype,
 						"http://downlode.org/Code/RDF/File_Properties/schema#Checksum");
 				hasDataMap.put(checksum, checksumMap);
 			}
@@ -892,6 +852,43 @@ public class JsonMapper {
 			return publicationYear.substring(0, 4);
 		}
 		return null;
+	}
+
+	private static Collection<Map<String, Object>> getType(final JsonNode rdf) {
+		Collection<Map<String, Object>> result = new ArrayList<>();
+
+		// Special case medium is video - override type
+		if (mediumArrayContains(rdf,
+				"http://rdaregistry.info/termList/RDAMediaType/1008")
+				|| mediumArrayContains(rdf,
+						"http://rdvocab.info/termList/RDACarrierType/1050")) {
+			String s = "http://rdaregistry.info/termList/RDAMediaType/1008";
+			Map<String, Object> tmap = new HashMap<>();
+			tmap.put(PREF_LABEL, Globals.profile.getEtikett(s).getLabel());
+			tmap.put(ID2, s);
+			result.add(tmap);
+
+		}
+		JsonNode types = rdf.at("/rdftype");
+		types.forEach(t -> {
+			String typeId = t.at("/@id").asText();
+			Map<String, Object> tmap = new HashMap<>();
+			tmap.put(PREF_LABEL, Globals.profile.getEtikett(typeId).getLabel());
+			tmap.put(ID2, typeId);
+			result.add(tmap);
+
+		});
+		return result;
+	}
+
+	private static boolean mediumArrayContains(JsonNode rdf, String key) {
+		boolean result = false;
+		JsonNode mediumArray = rdf.at("/medium");
+		for (JsonNode item : mediumArray) {
+			if (key.equals(item.at("/@id").asText("no Value found")))
+				result = true;
+		}
+		return result;
 	}
 
 }

--- a/app/helper/JsonMapper.java
+++ b/app/helper/JsonMapper.java
@@ -892,11 +892,12 @@ public class JsonMapper {
 		JsonNode types = rdf.at("/rdftype");
 		types.forEach(t -> {
 			String typeId = t.at("/@id").asText();
-			Map<String, Object> tmap = new HashMap<>();
-			tmap.put(PREF_LABEL, Globals.profile.getEtikett(typeId).getLabel());
-			tmap.put(ID2, typeId);
-			result.add(tmap);
-
+			if (!"http://purl.org/dc/terms/BibliographicResource".equals(typeId)) {
+				Map<String, Object> tmap = new HashMap<>();
+				tmap.put(PREF_LABEL, Globals.profile.getEtikett(typeId).getLabel());
+				tmap.put(ID2, typeId);
+				result.add(tmap);
+			}
 		});
 		return result;
 	}

--- a/app/helper/JsonMapper.java
+++ b/app/helper/JsonMapper.java
@@ -598,17 +598,13 @@ public class JsonMapper {
 		Collection<String> types = (Collection<String>) rdf.get(type);
 		play.Logger.trace("Found types: " + types);
 		if (types != null) {
-			for (String s : typePrios) {
-				if (s == null)
+			for (String t : types) {
+				if (t == null || "BibliographicResource".equals(t))
 					continue;
-				play.Logger.trace("Search for type: " + s);
-				if (types.contains(Globals.profile.getEtikett(s).name)) {
-					Map<String, Object> tmap = new HashMap<>();
-					tmap.put(PREF_LABEL, Globals.profile.getEtikett(s).getLabel());
-					tmap.put(ID2, s);
-					result.add(tmap);
-					return result;
-				}
+				Map<String, Object> tmap = new HashMap<>();
+				tmap.put(PREF_LABEL, Globals.profile.getEtikett(t).getLabel());
+				tmap.put(ID2, t);
+				result.add(tmap);
 			}
 		}
 		return result;

--- a/app/helper/JsonMapper.java
+++ b/app/helper/JsonMapper.java
@@ -419,8 +419,10 @@ public class JsonMapper {
 				Map<String, Object> fundingJoinedMap = new LinkedHashMap<>();
 				fundingJoinedMap.put("@id", Globals.protocol + Globals.server
 						+ "/adhoc/uri/" + helper.MyURLEncoding.encode(funding));
+				fundingJoinedMap.put("prefLabel", funding);
+				fundingId.add(fundingJoinedMap);
 			}
-			// rdf.remove("funding");
+			rdf.remove("funding");
 		}
 		List<String> fundingProgram = (List<String>) rdf.get("fundingProgram");
 		List<String> projectId = (List<String>) rdf.get("projectId");

--- a/app/helper/JsonMapper.java
+++ b/app/helper/JsonMapper.java
@@ -111,6 +111,7 @@ public class JsonMapper {
 			"http://purl.org/ontology/bibo/AudioDocument",
 			"http://purl.org/ontology/bibo/Image",
 			"http://purl.org/ontology/bibo/Article",
+			"http://purl.org/ontology/bibo/Chapter",
 			"http://rdvocab.info/termList/RDACarrierType/1018",
 			"http://rdvocab.info/termList/RDACarrierType/1010",
 			"http://iflastandards.info/ns/isbd/terms/mediatype/T1002",

--- a/app/helper/oai/WglMapper.java
+++ b/app/helper/oai/WglMapper.java
@@ -23,6 +23,7 @@ import java.util.List;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import de.hbz.lobid.helper.LobidTypes;
 import models.DublinCoreData;
 import models.Globals;
 import models.Node;
@@ -49,6 +50,7 @@ public class WglMapper {
 		JsonNode n = new ObjectMapper().valueToTree(node.getLd2());
 		data.setWglContributor(getWglContributor(n));
 		data.setWglSubject(getWglSubject(n));
+		data.setWglType(getWglType(n));
 		data.setCreator(getCreator(n));
 		data.setDescription(getList(n, "/abstractText"));
 		data.setTitle(getList(n, "/title"));
@@ -142,6 +144,38 @@ public class WglMapper {
 			result.addAll(getList(n, "/contributorName"));
 		}
 		return result;
+	}
+
+	private List<String> getWglType(JsonNode n) {
+		List<String> result = new ArrayList<>();
+		JsonNode a = n.at("/rdftype");
+		a.forEach(type -> {
+			String lobidType = type.at("/@id").textValue();
+			String wglType = mapLobidType(lobidType);
+			if (wglType != null) {
+				result.add(wglType);
+			}
+		});
+		return result;
+	}
+
+	private String mapLobidType(String lobidType) {
+		if (LobidTypes.Book.equals(lobidType)) {
+			return "Buch / Sammelwerk";
+		} else if (LobidTypes.Chapter.equals(lobidType)) {
+			return "Buchkapitel / Sammelwerksbeitrag";
+		} else if (LobidTypes.Thesis.equals(lobidType)) {
+			return "Hochschulschrift";
+		} else if (LobidTypes.Proceedings.equals(lobidType)) {
+			return "Konferenzbeitrag";
+		} else if (LobidTypes.Report.equals(lobidType)) {
+			return "Report / Forschungsbericht / Arbeitspapier";
+		} else if (LobidTypes.Miscellaneous.equals(lobidType)) {
+			return "Sonstige";
+		} else if (LobidTypes.Article.equals(lobidType)) {
+			return "Zeitschriftenartikel";
+		}
+		return null;
 	}
 
 	private List<String> getWglSubject(JsonNode n) {

--- a/app/models/DublinCoreData.java
+++ b/app/models/DublinCoreData.java
@@ -49,16 +49,42 @@ public class DublinCoreData implements java.io.Serializable {
 	List<String> type = new Vector<>();
 	List<String> wglcontributor = new Vector<>();
 	List<String> wglSubject = new Vector<>();
+	List<String> wglType = new Vector<>();
 
 	/**
 	 * @return wgl:wglcontributor
+	 */
+	public List<String> getWglType() {
+		return removeDuplicateEntries(wglType);
+	}
+
+	/**
+	 * @param cwgl:wglcontributor
+	 * @return this
+	 */
+	public DublinCoreData setWglType(List<String> wglType) {
+		this.wglType = wglType;
+		return this;
+	}
+
+	/**
+	 * @param e wgl:wglcontributor
+	 * @return this
+	 */
+	public DublinCoreData addWglType(String e) {
+		wglType.add(e);
+		return this;
+	}
+
+	/**
+	 * @return wgl:wglsubject
 	 */
 	public List<String> getWglSubject() {
 		return removeDuplicateEntries(wglSubject);
 	}
 
 	/**
-	 * @param cwgl:wglcontributor
+	 * @param cwgl:wglsubject
 	 * @return this
 	 */
 	public DublinCoreData setWglSubject(List<String> wglSubject) {
@@ -67,7 +93,7 @@ public class DublinCoreData implements java.io.Serializable {
 	}
 
 	/**
-	 * @param e wgl:wglcontributor
+	 * @param e wgl:wglsubject
 	 * @return this
 	 */
 	public DublinCoreData addWglSubject(String e) {

--- a/app/views/oai/wglView.scala.html
+++ b/app/views/oai/wglView.scala.html
@@ -57,5 +57,8 @@
 @field(data.getWglSubject(),"wgl:wglsubject")
 @field(data.getRights(),"wgl:rights")
 @typedField(data.getIdentifier(),"wgl:identifier")
-<wgl:wgltype>Zeitschriftenartikel</wgl:wgltype>
+@for(wgltype<-data.getWglType()){
+
+<wgl:wgltype>@wgltype</wgl:wgltype>
+}
 </oai_wgl:wgl>

--- a/app/views/tags/resourceView.scala.html
+++ b/app/views/tags/resourceView.scala.html
@@ -95,6 +95,22 @@
 		}
 		case "inCollection"=>{
 			
+		}case "fundingJoined"=>{
+		@values match {
+			case map:Map[String,String]=>{
+					<tr class="@key">
+						<td style="display:none;">@getWeight(key)</td>
+						<td class="field-label @key">@getLabel(key)</td>
+						<td class="field-item" property="@models.Globals.profile.getEtikettByName(key).getUri()">
+									    <a title="Ähnliche Objekte suchen" href="@models.Globals.rechercheUrlPrefix@map.get("prefLabel")@models.Globals.rechercheUrlSuffix">
+					                        @map.get("prefLabel")
+					                    </a>
+					              
+									</ul>
+											
+					</tr>
+				} case _ =>{} 
+			}
 		}
 		case "hasData"=>{
 			@values match {
@@ -603,6 +619,7 @@
 			case _ => {		
 				<table class="table table-striped table-condensed">
 				@htmlRow(map,"")
+				
 				</table>
 			}
 		}

--- a/app/views/tags/resourceView.scala.html
+++ b/app/views/tags/resourceView.scala.html
@@ -55,7 +55,6 @@
 
 
 @htmlRow(values: Any,key: String)={
-
 	@key match {
 		case "hasPart"=>{
 			@values match {
@@ -457,8 +456,7 @@
 					                    </a>
 					                 </li>
 									}
-									</ul>
-											
+									</ul>		
 					</tr>
 				}
 				case map:Map[String,String]=>{

--- a/app/views/tags/resourceView.scala.html
+++ b/app/views/tags/resourceView.scala.html
@@ -96,21 +96,24 @@
 		case "inCollection"=>{
 			
 		}case "fundingJoined"=>{
-		@values match {
-			case map:Map[String,String]=>{
-					<tr class="@key">
-						<td style="display:none;">@getWeight(key)</td>
-						<td class="field-label @key">@getLabel(key)</td>
-						<td class="field-item" property="@models.Globals.profile.getEtikettByName(key).getUri()">
-									    <a title="Ähnliche Objekte suchen" href="@models.Globals.rechercheUrlPrefix@map.get("prefLabel")@models.Globals.rechercheUrlSuffix">
-					                        @map.get("prefLabel")
-					                    </a>
-					              
-									</ul>
-											
-					</tr>
-				} case _ =>{} 
-			}
+			@values match {
+				case map:Map[String,String]=>{
+						<tr class="">
+							<td style="display:none;">@getWeight(key)</td>
+							<td class="field-label @key">@getLabel(key)</td>
+							<td class="field-item" property="@models.Globals.profile.getEtikettByName(key).getUri()">
+										    <a title="Ähnliche Objekte suchen" href="@models.Globals.rechercheUrlPrefix@map.get("prefLabel")@models.Globals.rechercheUrlSuffix">
+						                        @map.get("prefLabel")
+						                    </a>
+						              		<span class="separator">|</span>
+						                    <a href=@map.get("@id")  target="_blank">
+						                               <span class="octicon-link-external"></span>
+						                    </a>
+										</ul>
+												
+						</tr>
+					} case _ =>{} 
+				}
 		}
 		case "hasData"=>{
 			@values match {

--- a/conf/labels-publisso.de
+++ b/conf/labels-publisso.de
@@ -28,7 +28,7 @@
   "name" : "role",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "85",
+  "weight" : "86",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -69,7 +69,7 @@
   "name" : "ConferenceOrEvent",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "176",
+  "weight" : "182",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -80,7 +80,7 @@
   "name" : "CorporateBody",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "177",
+  "weight" : "183",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -91,7 +91,7 @@
   "name" : "DifferentiatedPerson",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "178",
+  "weight" : "184",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -102,7 +102,7 @@
   "name" : "Family",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "179",
+  "weight" : "185",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -113,7 +113,7 @@
   "name" : "Person",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "180",
+  "weight" : "186",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -124,7 +124,7 @@
   "name" : "PlaceOrGeographicName",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "181",
+  "weight" : "187",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -135,7 +135,7 @@
   "name" : "SubjectHeading",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "182",
+  "weight" : "188",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -146,7 +146,7 @@
   "name" : "Work",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "183",
+  "weight" : "189",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -157,7 +157,7 @@
   "name" : "dateOfBirth",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "94",
+  "weight" : "95",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -168,7 +168,7 @@
   "name" : "dateOfDeath",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "95",
+  "weight" : "96",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -179,7 +179,7 @@
   "name" : "preferredName",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "96",
+  "weight" : "97",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -187,7 +187,7 @@
   "label" : "",
   "name" : "preferredNameEntityForThePerson",
   "referenceType" : "String",
-  "weight" : "97",
+  "weight" : "98",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -195,7 +195,7 @@
   "label" : "",
   "name" : "preferredNameForTheConferenceOrEvent",
   "referenceType" : "String",
-  "weight" : "98",
+  "weight" : "99",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -206,7 +206,7 @@
   "name" : "preferredNameForTheCorporateBody",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "99",
+  "weight" : "100",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -214,7 +214,7 @@
   "label" : "",
   "name" : "preferredNameForTheFamily",
   "referenceType" : "String",
-  "weight" : "100",
+  "weight" : "101",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -225,7 +225,7 @@
   "name" : "preferredNameForThePerson",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "102",
+  "weight" : "103",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -233,7 +233,7 @@
   "label" : "",
   "name" : "preferredNameForThePlaceOrGeographicName",
   "referenceType" : "String",
-  "weight" : "103",
+  "weight" : "104",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -241,7 +241,7 @@
   "label" : "",
   "name" : "preferredNameForTheSubjectHeading",
   "referenceType" : "String",
-  "weight" : "104",
+  "weight" : "105",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -249,7 +249,7 @@
   "label" : "",
   "name" : "preferredNameForTheWork",
   "referenceType" : "String",
-  "weight" : "105",
+  "weight" : "106",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -273,7 +273,7 @@
 }, {
   "uri" : "http://dbpedia.org/ontology/institution",
   "comment" : "",
-  "label" : "Sammlung",
+  "label" : "FRL-Sammlung",
   "icon" : "",
   "name" : "institution",
   "referenceType" : "@id",
@@ -5859,7 +5859,7 @@
   "name" : "checksum",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "106",
+  "weight" : "107",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -5867,7 +5867,7 @@
   "label" : "",
   "name" : "generator",
   "referenceType" : "@id",
-  "weight" : "107",
+  "weight" : "108",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -5875,7 +5875,7 @@
   "label" : "Größe",
   "name" : "size",
   "referenceType" : "String",
-  "weight" : "108",
+  "weight" : "109",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -5891,7 +5891,7 @@
   "name" : "hasURN",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "80",
+  "weight" : "81",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6122,7 +6122,7 @@
   "name" : "accessScheme",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "219",
+  "weight" : "225",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6144,7 +6144,7 @@
   "name" : "agrovoc",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "109",
+  "weight" : "110",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6198,7 +6198,7 @@
   "name" : "catalogLink",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "82",
+  "weight" : "83",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6275,7 +6275,7 @@
   "name" : "contentType",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "211",
+  "weight" : "217",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6283,7 +6283,7 @@
   "label" : "Erstellt von",
   "name" : "createdBy",
   "referenceType" : "String",
-  "weight" : "110",
+  "weight" : "111",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6294,7 +6294,7 @@
   "name" : "dataOrigin",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "111",
+  "weight" : "112",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6305,7 +6305,7 @@
   "name" : "ddc",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "112",
+  "weight" : "113",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6316,7 +6316,7 @@
   "name" : "doi",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "113",
+  "weight" : "114",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6338,7 +6338,7 @@
   "name" : "funding",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "172",
+  "weight" : "173",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6349,7 +6349,7 @@
   "name" : "fundingJoined",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "172",
+  "weight" : "174",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6360,7 +6360,7 @@
   "name" : "fundingProgram",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "174",
+  "weight" : "178",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6371,7 +6371,7 @@
   "name" : "fundingProgramJoined",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "174",
+  "weight" : "179",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6382,7 +6382,7 @@
   "name" : "hasData",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "114",
+  "weight" : "115",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6393,7 +6393,7 @@
   "name" : "hasTransformer",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "115",
+  "weight" : "116",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6401,7 +6401,7 @@
   "label" : "Import",
   "name" : "importedFrom",
   "referenceType" : "String",
-  "weight" : "116",
+  "weight" : "117",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6412,7 +6412,7 @@
   "name" : "externalParent",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "83",
+  "weight" : "84",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6441,7 +6441,7 @@
   "label" : "Bearbeitet von",
   "name" : "lastModifiedBy",
   "referenceType" : "String",
-  "weight" : "117",
+  "weight" : "118",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6449,7 +6449,7 @@
   "label" : "Id Altsystem",
   "name" : "legacyId",
   "referenceType" : "String",
-  "weight" : "118",
+  "weight" : "119",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6468,7 +6468,7 @@
   "label" : "Interner Name",
   "name" : "name",
   "referenceType" : "String",
-  "weight" : "119",
+  "weight" : "120",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6479,7 +6479,7 @@
   "name" : "nextVersion",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "87",
+  "weight" : "88",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6490,7 +6490,7 @@
   "name" : "objectTimestamp",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "120",
+  "weight" : "121",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6522,7 +6522,7 @@
   "name" : "parallelEdition",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "226",
+  "weight" : "232",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6563,7 +6563,7 @@
   "name" : "previousVersion",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "88",
+  "weight" : "89",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6574,7 +6574,7 @@
   "name" : "professionalGroup",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "76",
+  "weight" : "77",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6585,7 +6585,18 @@
   "name" : "projectId",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "173",
+  "weight" : "175",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
+  "uri" : "http://hbz-nrw.de/regal#projectIdJoin",
+  "comment" : "",
+  "label" : "Fördernummer",
+  "icon" : "",
+  "name" : "projectIdJoin",
+  "referenceType" : "String",
+  "container" : "",
+  "weight" : "176",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6596,7 +6607,7 @@
   "name" : "projectIdJoined",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "173",
+  "weight" : "177",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6607,7 +6618,7 @@
   "name" : "publicationStatus",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "70",
+  "weight" : "71",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6629,7 +6640,7 @@
   "name" : "publishScheme",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "218",
+  "weight" : "224",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6640,7 +6651,7 @@
   "name" : "recordingCoordinates",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "89",
+  "weight" : "90",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6651,7 +6662,7 @@
   "name" : "recordingLocation",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "90",
+  "weight" : "91",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6662,7 +6673,7 @@
   "name" : "recordingPeriod",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "91",
+  "weight" : "92",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6684,7 +6695,7 @@
   "name" : "relatedResource",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "92",
+  "weight" : "93",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6695,7 +6706,7 @@
   "name" : "reviewStatus",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "71",
+  "weight" : "72",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6798,7 +6809,7 @@
   "name" : "extent",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "207",
+  "weight" : "213",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6809,7 +6820,7 @@
   "name" : "frequency",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "159",
+  "weight" : "160",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6820,7 +6831,7 @@
   "name" : "hasItem",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "225",
+  "weight" : "231",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6831,7 +6842,7 @@
   "name" : "heldBy",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "203",
+  "weight" : "209",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6842,7 +6853,7 @@
   "name" : "itemOf",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "204",
+  "weight" : "210",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6864,7 +6875,7 @@
   "name" : "role",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "86",
+  "weight" : "87",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6875,7 +6886,7 @@
   "name" : "source",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "131",
+  "weight" : "132",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6886,7 +6897,7 @@
   "name" : "supplement",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "205",
+  "weight" : "211",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -7935,6 +7946,16 @@
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
+  "uri" : "http://id.loc.gov/vocabulary/relators/oth",
+  "comment" : "",
+  "label" : "Sonstige",
+  "icon" : "",
+  "name" : "",
+  "container" : "",
+  "weight" : "",
+  "type" : "STORE",
+  "multilangLabel" : { }
+}, {
   "uri" : "http://id.loc.gov/vocabulary/relators/pht",
   "label" : "Fotografie",
   "type" : "STORE",
@@ -7979,7 +8000,7 @@
   "label" : "Gesamttitel",
   "name" : "P1004",
   "referenceType" : "String",
-  "weight" : "121",
+  "weight" : "122",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -7990,7 +8011,7 @@
   "name" : "P1006",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "122",
+  "weight" : "123",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8001,7 +8022,7 @@
   "name" : "P1016",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "123",
+  "weight" : "124",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8020,7 +8041,7 @@
   "label" : "Kombination",
   "name" : "T1008",
   "referenceType" : "String",
-  "weight" : "124",
+  "weight" : "125",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8230,7 +8251,7 @@
   "name" : "fulltextOnline",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "224",
+  "weight" : "230",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8382,7 +8403,7 @@
   "name" : "coverage",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "125",
+  "weight" : "126",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8404,7 +8425,7 @@
   "name" : "isPartOfName",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "171",
+  "weight" : "172",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8415,7 +8436,7 @@
   "name" : "publisher",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "77",
+  "weight" : "78",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8426,7 +8447,7 @@
   "name" : "subjectName",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "75",
+  "weight" : "76",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8444,7 +8465,7 @@
   "name" : "abstractText",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "73",
+  "weight" : "74",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8488,7 +8509,7 @@
   "name" : "created",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "126",
+  "weight" : "127",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8508,7 +8529,7 @@
   "name" : "description",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "127",
+  "weight" : "128",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8516,7 +8537,7 @@
   "label" : "Format",
   "name" : "format",
   "referenceType" : "String",
-  "weight" : "128",
+  "weight" : "129",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8525,7 +8546,7 @@
   "name" : "hasFormat",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "129",
+  "weight" : "130",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8536,7 +8557,7 @@
   "name" : "hasPart",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "175",
+  "weight" : "180",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8547,7 +8568,7 @@
   "name" : "hasVersion",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "222",
+  "weight" : "228",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8558,7 +8579,7 @@
   "name" : "primaryForm",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "192",
+  "weight" : "198",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8569,7 +8590,7 @@
   "name" : "parentPid",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "84",
+  "weight" : "85",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8591,7 +8612,7 @@
   "name" : "language",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "72",
+  "weight" : "73",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8613,7 +8634,7 @@
   "name" : "modified",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "130",
+  "weight" : "131",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8624,7 +8645,7 @@
   "name" : "source",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "132",
+  "weight" : "133",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8635,7 +8656,7 @@
   "name" : "spatial",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "133",
+  "weight" : "134",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8646,7 +8667,7 @@
   "name" : "subject",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "74",
+  "weight" : "75",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8657,7 +8678,7 @@
   "name" : "tableOfContents",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "134",
+  "weight" : "135",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8693,7 +8714,7 @@
   "name" : "Game",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "184",
+  "weight" : "190",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8756,7 +8777,7 @@
   "name" : "MultiVolumeWorkRelation",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "185",
+  "weight" : "191",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8767,7 +8788,7 @@
   "name" : "OfficialPublication",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "186",
+  "weight" : "192",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8778,7 +8799,7 @@
   "name" : "Schoolbook",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "187",
+  "weight" : "193",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8789,7 +8810,7 @@
   "name" : "SeriesRelation",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "188",
+  "weight" : "194",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8821,7 +8842,7 @@
   "name" : "contributorOrder",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "135",
+  "weight" : "136",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8832,7 +8853,7 @@
   "name" : "fulltextOnline",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "136",
+  "weight" : "137",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8843,7 +8864,7 @@
   "name" : "hasSuperordinate",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "193",
+  "weight" : "199",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8865,7 +8886,7 @@
   "name" : "inCollection",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "194",
+  "weight" : "200",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8896,7 +8917,7 @@
   "name" : "multiVolumeWork",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "137",
+  "weight" : "138",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8905,7 +8926,7 @@
   "name" : "contributingCorporateBodyLabel",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "138",
+  "weight" : "139",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8916,7 +8937,7 @@
   "name" : "numbering",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "139",
+  "weight" : "140",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8927,7 +8948,7 @@
   "name" : "nwbibspatial",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "140",
+  "weight" : "141",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8938,7 +8959,7 @@
   "name" : "nwbibsubject",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "141",
+  "weight" : "142",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8960,7 +8981,7 @@
   "name" : "series",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "170",
+  "weight" : "171",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8971,7 +8992,7 @@
   "name" : "subjectAltLabel",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "209",
+  "weight" : "215",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8982,7 +9003,7 @@
   "name" : "subjectChain",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "101",
+  "weight" : "102",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8993,7 +9014,7 @@
   "name" : "subjectLabel",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "208",
+  "weight" : "214",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -9002,7 +9023,7 @@
   "name" : "subjectLocation",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "142",
+  "weight" : "143",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -9013,7 +9034,7 @@
   "name" : "subjectOrder",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "143",
+  "weight" : "144",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -9024,7 +9045,7 @@
   "name" : "titleKeyword",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "93",
+  "weight" : "94",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -9035,7 +9056,7 @@
   "name" : "urn",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "81",
+  "weight" : "82",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19797,20 +19818,22 @@
   "comment" : "",
   "label" : "Artikel",
   "icon" : "octicon octicon-file-text",
-  "name" : "article",
+  "name" : "Article",
+  "referenceType" : "@id",
   "container" : "",
   "weight" : "",
-  "type" : "STORE",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/AudioDocument",
   "comment" : "",
   "label" : "Audio-Dokument",
   "icon" : "",
-  "name" : "audioDocument",
+  "name" : "AudioDocument",
+  "referenceType" : "@id",
   "container" : "",
   "weight" : "",
-  "type" : "STORE",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/AudioVisualDocument",
@@ -19818,16 +19841,21 @@
   "label" : "Audio-Visuell",
   "icon" : "",
   "name" : "bibo:AudioVisual",
+  "referenceType" : "@id",
   "container" : "",
   "weight" : "",
-  "type" : "STORE",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Book",
+  "comment" : "",
   "label" : "Buch",
   "icon" : "fa fa-book",
   "name" : "Book",
-  "type" : "STORE",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Chapter",
@@ -19835,65 +19863,87 @@
   "label" : "Kapitel",
   "icon" : "",
   "name" : "Chapter",
+  "referenceType" : "@id",
   "container" : "",
   "weight" : "",
-  "type" : "STORE",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Collection",
+  "comment" : "",
   "label" : "Sammlung",
   "icon" : "glyphicon glyphicon-th-large",
   "name" : "Collection",
-  "type" : "STORE",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/DocumentPart",
   "comment" : "",
   "label" : "Unterordnung",
   "icon" : "fa fa-folder-o",
-  "name" : "documentPart",
+  "name" : "DocumentPart",
+  "referenceType" : "@id",
   "container" : "",
   "weight" : "",
-  "type" : "STORE",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Image",
+  "comment" : "",
   "label" : "Bild",
   "icon" : "fa fa-file-image-o",
   "name" : "Image",
-  "type" : "STORE",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Issue",
   "comment" : "",
   "label" : "Ausgabe",
   "icon" : "fa fa-clone",
-  "name" : "issue",
+  "name" : "Issue",
+  "referenceType" : "@id",
   "container" : "",
   "weight" : "",
-  "type" : "STORE",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Journal",
+  "comment" : "",
   "label" : "Journal",
   "icon" : "fa fa-newspaper-o",
   "name" : "Journal",
-  "type" : "STORE",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Manuscript",
+  "comment" : "",
   "label" : "Manuskript",
-  "type" : "STORE",
+  "icon" : "",
+  "name" : "Manuscript",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Map",
   "comment" : "",
   "label" : "Karte",
   "icon" : "",
-  "name" : "map",
+  "name" : "Map",
+  "referenceType" : "@id",
   "container" : "",
   "weight" : "",
-  "type" : "STORE",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/MultiVolumeBook",
@@ -19901,33 +19951,43 @@
   "label" : "Mehrbändiges Werk",
   "icon" : "",
   "name" : "MultiVolumeBook",
+  "referenceType" : "@id",
   "container" : "",
   "weight" : "",
-  "type" : "STORE",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Newspaper",
+  "comment" : "",
   "label" : "Zeitung",
   "icon" : "octicon octicon-book",
   "name" : "Newspaper",
-  "type" : "STORE",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Periodical",
+  "comment" : "",
   "label" : "Periodikum",
   "icon" : "fa fa-newspaper-o",
   "name" : "Periodical",
-  "type" : "STORE",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Proceedings",
   "comment" : "Markdown provides backslash escapes for the following characters:\r\n\r\n    \\   backslash\r\n    `   backtick\r\n    *   asterisk\r\n    _   underscore\r\n    {}  curly braces\r\n    []  square brackets\r\n    ()  parentheses\r\n    #   hash mark\r\n\t+\tplus sign\r\n\t-\tminus sign (hyphen)\r\n    .   dot\r\n    !   exclamation mark\r\n\r\n",
   "label" : "Konferenzschrift",
   "icon" : "octicon octicon-three-bars",
-  "name" : "proceeding",
+  "name" : "Proceeding",
+  "referenceType" : "@id",
   "container" : "",
   "weight" : "2",
-  "type" : "STORE",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/ReferenceSource",
@@ -19937,7 +19997,7 @@
   "name" : "ReferenceSource",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "189",
+  "weight" : "195",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19948,15 +20008,19 @@
   "name" : "Report",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "190",
+  "weight" : "196",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Series",
+  "comment" : "",
   "label" : "Reihe",
   "icon" : "glyphicon glyphicon-th-large",
-  "name" : "series",
-  "type" : "STORE",
+  "name" : "Series",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Standard",
@@ -19964,16 +20028,21 @@
   "label" : "Leitlinien / Normschriften",
   "icon" : "fa fa-university ",
   "name" : "Standard",
+  "referenceType" : "@id",
   "container" : "",
   "weight" : "",
-  "type" : "STORE",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Thesis",
+  "comment" : "",
   "label" : "Abschlussarbeit",
   "icon" : "octicon octicon-mortar-board",
   "name" : "Thesis",
-  "type" : "STORE",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Volume",
@@ -19981,9 +20050,10 @@
   "label" : "Jahrgang",
   "icon" : "fa fa-calendar-o",
   "name" : "volume",
+  "referenceType" : "@id",
   "container" : "",
   "weight" : "",
-  "type" : "STORE",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/doi",
@@ -19993,7 +20063,7 @@
   "name" : "bibo:doi",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "78",
+  "weight" : "79",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20010,12 +20080,12 @@
 }, {
   "uri" : "http://purl.org/ontology/bibo/editor",
   "comment" : "",
-  "label" : "Herausgeber/in",
+  "label" : "(Academic) Editor",
   "icon" : "",
   "name" : "editor",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "144",
+  "weight" : "145",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20037,7 +20107,7 @@
   "name" : "Isbn",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "145",
+  "weight" : "146",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20048,7 +20118,7 @@
   "name" : "isbn",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "146",
+  "weight" : "147",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20059,7 +20129,7 @@
   "name" : "isbn13",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "147",
+  "weight" : "148",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20078,7 +20148,7 @@
   "label" : "Lccn",
   "name" : "lccn",
   "referenceType" : "String",
-  "weight" : "148",
+  "weight" : "149",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20087,9 +20157,10 @@
   "label" : "",
   "icon" : "",
   "name" : "oclcNumber",
+  "referenceType" : "@id",
   "container" : "@set",
   "weight" : "",
-  "type" : "STORE",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/shortTitle",
@@ -20121,7 +20192,7 @@
   "name" : "callNumber",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "149",
+  "weight" : "150",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20132,7 +20203,7 @@
   "name" : "collectedBy",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "150",
+  "weight" : "151",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20158,7 +20229,7 @@
   "name" : "ismn",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "151",
+  "weight" : "152",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20169,7 +20240,7 @@
   "name" : "wikipedia",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "152",
+  "weight" : "153",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20180,7 +20251,7 @@
   "name" : "Item",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "191",
+  "weight" : "197",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20195,7 +20266,7 @@
   "label" : "Exemplar",
   "name" : "exemplar",
   "referenceType" : "String",
-  "weight" : "153",
+  "weight" : "154",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20204,7 +20275,7 @@
   "name" : "exemplarOf",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "154",
+  "weight" : "155",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20213,7 +20284,7 @@
   "name" : "owner",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "155",
+  "weight" : "156",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20222,7 +20293,7 @@
   "name" : "isSupplementTo",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "156",
+  "weight" : "157",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20233,7 +20304,7 @@
   "name" : "predecessor",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "195",
+  "weight" : "201",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20244,7 +20315,7 @@
   "name" : "successor",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "196",
+  "weight" : "202",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20253,7 +20324,7 @@
   "name" : "hasSupplement",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "157",
+  "weight" : "158",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20264,7 +20335,7 @@
   "name" : "corporateBodyForTitle",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "197",
+  "weight" : "203",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20275,7 +20346,7 @@
   "name" : "P60489",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "158",
+  "weight" : "159",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20308,7 +20379,7 @@
   "name" : "natureOfContent",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "210",
+  "weight" : "216",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20342,7 +20413,7 @@
   "name" : "frequency",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "160",
+  "weight" : "161",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20351,7 +20422,7 @@
   "name" : "longitudeAndLatitude",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "161",
+  "weight" : "162",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20406,7 +20477,7 @@
   "name" : "workManifested",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "162",
+  "weight" : "163",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20458,7 +20529,7 @@
   "name" : "endDate",
   "referenceType" : "http://www.w3.org/2001/XMLSchema#gYear",
   "container" : "@set",
-  "weight" : "198",
+  "weight" : "204",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20469,7 +20540,7 @@
   "name" : "location",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "199",
+  "weight" : "205",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20491,7 +20562,7 @@
   "name" : "publishedBy",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "206",
+  "weight" : "212",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20502,7 +20573,7 @@
   "name" : "startDate",
   "referenceType" : "http://www.w3.org/2001/XMLSchema#gYear",
   "container" : "@set",
-  "weight" : "200",
+  "weight" : "206",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20633,7 +20704,7 @@
   "name" : "isLike",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "212",
+  "weight" : "218",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20659,7 +20730,7 @@
   "name" : "componentList",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "201",
+  "weight" : "207",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20670,7 +20741,7 @@
   "name" : "itemID",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "216",
+  "weight" : "222",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20678,7 +20749,7 @@
   "label" : "beschreibt",
   "name" : "describes",
   "referenceType" : "@id",
-  "weight" : "163",
+  "weight" : "164",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20689,7 +20760,7 @@
   "name" : "isAggregatedBy",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "164",
+  "weight" : "165",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20697,7 +20768,7 @@
   "label" : "Beschrieben durch",
   "name" : "isDescribedBy",
   "referenceType" : "@id",
-  "weight" : "213",
+  "weight" : "219",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20708,7 +20779,7 @@
   "name" : "similarTo",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "223",
+  "weight" : "229",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20719,7 +20790,7 @@
   "name" : "isLike",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "214",
+  "weight" : "220",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20729,7 +20800,7 @@
   "icon" : "",
   "name" : "rdftype",
   "referenceType" : "@id",
-  "container" : "",
+  "container" : "@set",
   "weight" : "59",
   "type" : "CONTEXT",
   "multilangLabel" : { }
@@ -20738,7 +20809,7 @@
   "label" : "",
   "name" : "inDataset",
   "referenceType" : "String",
-  "weight" : "165",
+  "weight" : "166",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20760,7 +20831,7 @@
   "name" : "seeAlso",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "166",
+  "weight" : "167",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20771,7 +20842,7 @@
   "name" : "xsd",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "167",
+  "weight" : "168",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20782,7 +20853,7 @@
   "name" : "sameAs",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "217",
+  "weight" : "223",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20793,7 +20864,7 @@
   "name" : "altLabel",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "202",
+  "weight" : "208",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20802,7 +20873,7 @@
   "name" : "note",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "168",
+  "weight" : "169",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20813,7 +20884,7 @@
   "name" : "prefLabel",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "169",
+  "weight" : "170",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20832,7 +20903,7 @@
   "label" : "Beschrieben durch",
   "name" : "describedby",
   "referenceType" : "@id",
-  "weight" : "220",
+  "weight" : "226",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20840,7 +20911,7 @@
   "label" : "Gegenstand von",
   "name" : "isPrimaryTopicOf",
   "referenceType" : "@id",
-  "weight" : "221",
+  "weight" : "227",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20851,7 +20922,7 @@
   "name" : "primaryTopic",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "215",
+  "weight" : "221",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -21264,7 +21335,7 @@
   "name" : "joinedFunding",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "175",
+  "weight" : "181",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -21322,9 +21393,30 @@
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
+  "uri" : "info:regal/zettel/additionalNotes",
+  "comment" : "",
+  "label" : "Hinweis",
+  "icon" : "",
+  "name" : "additionalNotes",
+  "referenceType" : "String",
+  "container" : "",
+  "weight" : "170",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
+  "uri" : "info:regal/zettel/additionalNotesHeader",
+  "comment" : "",
+  "label" : "Erweiterte Angaben",
+  "icon" : "",
+  "name" : "",
+  "container" : "",
+  "weight" : "",
+  "type" : "STORE",
+  "multilangLabel" : { }
+}, {
   "uri" : "info:regal/zettel/catalogingHeader",
   "comment" : "",
-  "label" : "Inhaltliche Angaben",
+  "label" : "Angaben zum Inhalt",
   "icon" : "",
   "name" : "",
   "container" : "",
@@ -21368,7 +21460,7 @@
 }, {
   "uri" : "info:regal/zettel/creatorshipHeader",
   "comment" : "",
-  "label" : "Urheberschaft",
+  "label" : "Angaben zur Urheberschaft",
   "icon" : "",
   "name" : "",
   "container" : "",
@@ -21383,7 +21475,7 @@
   "name" : "fulltextVersion",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "79",
+  "weight" : "80",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -21399,12 +21491,23 @@
 }, {
   "uri" : "info:regal/zettel/identifiersHeader",
   "comment" : "",
-  "label" : "Externe Referenzen",
+  "label" : "Externe und interne Referenzen",
   "icon" : "",
   "name" : "",
   "container" : "",
   "weight" : "",
   "type" : "STORE",
+  "multilangLabel" : { }
+}, {
+  "uri" : "info:regal/zettel/internalReference",
+  "comment" : "",
+  "label" : "Interne Referenz",
+  "icon" : "",
+  "name" : "internalReference",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "70",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "info:regal/zettel/leibniz/org/BIPS",
@@ -21749,7 +21852,7 @@
 }, {
   "uri" : "info:regal/zettel/titleHeader",
   "comment" : "",
-  "label" : "Titelangaben",
+  "label" : "Angaben zum Titel",
   "icon" : "",
   "name" : "",
   "container" : "",
@@ -21764,8 +21867,12 @@
   "multilangLabel" : { }
 }, {
   "uri" : "info:regal/zettel/uploadHeader",
-  "label" : "Dateiupload",
-  "referenceType" : "String",
+  "comment" : "",
+  "label" : "Angaben zur Datei",
+  "icon" : "",
+  "name" : "",
+  "container" : "",
+  "weight" : "",
   "type" : "STORE",
   "multilangLabel" : { }
 }, {

--- a/conf/labels-publisso.de
+++ b/conf/labels-publisso.de
@@ -6342,6 +6342,17 @@
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
+  "uri" : "http://hbz-nrw.de/regal#fundingJoined",
+  "comment" : "",
+  "label" : "Förderer",
+  "icon" : "",
+  "name" : "fundingJoined",
+  "referenceType" : "String",
+  "container" : "",
+  "weight" : "172",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
   "uri" : "http://hbz-nrw.de/regal#fundingProgram",
   "comment" : "",
   "label" : "Förderprogramm",
@@ -6349,6 +6360,17 @@
   "name" : "fundingProgram",
   "referenceType" : "String",
   "container" : "@list",
+  "weight" : "174",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
+  "uri" : "http://hbz-nrw.de/regal#fundingProgramJoined",
+  "comment" : "",
+  "label" : "Förderprogramm",
+  "icon" : "",
+  "name" : "fundingProgramJoined",
+  "referenceType" : "String",
+  "container" : "",
   "weight" : "174",
   "type" : "CONTEXT",
   "multilangLabel" : { }
@@ -6563,6 +6585,17 @@
   "name" : "projectId",
   "referenceType" : "String",
   "container" : "@list",
+  "weight" : "173",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
+  "uri" : "http://hbz-nrw.de/regal#projectIdJoined",
+  "comment" : "",
+  "label" : "Fördernummer",
+  "icon" : "",
+  "name" : "projectIdJoined",
+  "referenceType" : "String",
+  "container" : "",
   "weight" : "173",
   "type" : "CONTEXT",
   "multilangLabel" : { }
@@ -21222,6 +21255,17 @@
   "uri" : "https://www.edoweb-rlp.de/resource",
   "label" : "Edoweb",
   "type" : "STORE",
+  "multilangLabel" : { }
+}, {
+  "uri" : "info:regal/regal/joinedFunding",
+  "comment" : "",
+  "label" : "Förderung",
+  "icon" : "",
+  "name" : "joinedFunding",
+  "referenceType" : "@id",
+  "container" : "@list",
+  "weight" : "175",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "info:regal/regal/publishLocation",

--- a/conf/labels-publisso.de
+++ b/conf/labels-publisso.de
@@ -69,7 +69,7 @@
   "name" : "ConferenceOrEvent",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "182",
+  "weight" : "184",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -80,7 +80,7 @@
   "name" : "CorporateBody",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "183",
+  "weight" : "185",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -91,7 +91,7 @@
   "name" : "DifferentiatedPerson",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "184",
+  "weight" : "186",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -102,7 +102,7 @@
   "name" : "Family",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "185",
+  "weight" : "187",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -113,7 +113,7 @@
   "name" : "Person",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "186",
+  "weight" : "188",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -124,7 +124,7 @@
   "name" : "PlaceOrGeographicName",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "187",
+  "weight" : "189",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -135,7 +135,7 @@
   "name" : "SubjectHeading",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "188",
+  "weight" : "190",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -146,7 +146,7 @@
   "name" : "Work",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "189",
+  "weight" : "191",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6122,7 +6122,7 @@
   "name" : "accessScheme",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "225",
+  "weight" : "227",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6159,7 +6159,7 @@
   "multilangLabel" : { }
 }, {
   "uri" : "http://hbz-nrw.de/regal#articleNumber",
-  "comment" : "**HELLO**",
+  "comment" : "",
   "label" : "Artikelnummer",
   "icon" : "",
   "name" : "articleNumber",
@@ -6275,7 +6275,7 @@
   "name" : "contentType",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "217",
+  "weight" : "219",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6338,7 +6338,18 @@
   "name" : "funding",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "173",
+  "weight" : "174",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
+  "uri" : "http://hbz-nrw.de/regal#fundingId",
+  "comment" : "",
+  "label" : "Förderer",
+  "icon" : "",
+  "name" : "fundingId",
+  "referenceType" : "@id",
+  "container" : "@list",
+  "weight" : "175",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6349,7 +6360,7 @@
   "name" : "fundingJoined",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "174",
+  "weight" : "176",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6360,7 +6371,7 @@
   "name" : "fundingProgram",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "178",
+  "weight" : "180",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6371,7 +6382,7 @@
   "name" : "fundingProgramJoined",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "179",
+  "weight" : "181",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6505,7 +6516,7 @@
   "multilangLabel" : { }
 }, {
   "uri" : "http://hbz-nrw.de/regal#pages",
-  "comment" : "**HELLO**",
+  "comment" : "",
   "label" : "Seiten",
   "icon" : "",
   "name" : "pages",
@@ -6522,7 +6533,7 @@
   "name" : "parallelEdition",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "232",
+  "weight" : "234",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6585,7 +6596,7 @@
   "name" : "projectId",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "175",
+  "weight" : "177",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6596,7 +6607,7 @@
   "name" : "projectIdJoin",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "176",
+  "weight" : "178",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6607,12 +6618,12 @@
   "name" : "projectIdJoined",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "177",
+  "weight" : "179",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://hbz-nrw.de/regal#publicationStatus",
-  "comment" : "**HELLO**",
+  "comment" : "",
   "label" : "Publikationsstatus",
   "icon" : "",
   "name" : "publicationStatus",
@@ -6640,7 +6651,7 @@
   "name" : "publishScheme",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "224",
+  "weight" : "226",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6743,7 +6754,7 @@
   "multilangLabel" : { }
 }, {
   "uri" : "http://hbz-nrw.de/regal#volume",
-  "comment" : "**HELLO**",
+  "comment" : "",
   "label" : "Band",
   "icon" : "",
   "name" : "volume",
@@ -6809,7 +6820,7 @@
   "name" : "extent",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "213",
+  "weight" : "215",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6831,7 +6842,7 @@
   "name" : "hasItem",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "231",
+  "weight" : "233",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6842,7 +6853,7 @@
   "name" : "heldBy",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "209",
+  "weight" : "211",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6853,7 +6864,7 @@
   "name" : "itemOf",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "210",
+  "weight" : "212",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6897,7 +6908,7 @@
   "name" : "supplement",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "211",
+  "weight" : "213",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -7950,10 +7961,11 @@
   "comment" : "",
   "label" : "Sonstige",
   "icon" : "",
-  "name" : "",
+  "name" : "Other",
+  "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
-  "type" : "STORE",
+  "weight" : "248",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://id.loc.gov/vocabulary/relators/pht",
@@ -8251,7 +8263,7 @@
   "name" : "fulltextOnline",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "230",
+  "weight" : "232",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8425,7 +8437,7 @@
   "name" : "isPartOfName",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "172",
+  "weight" : "173",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8557,7 +8569,7 @@
   "name" : "hasPart",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "180",
+  "weight" : "182",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8568,7 +8580,7 @@
   "name" : "hasVersion",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "228",
+  "weight" : "230",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8579,7 +8591,7 @@
   "name" : "primaryForm",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "198",
+  "weight" : "200",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8714,7 +8726,7 @@
   "name" : "Game",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "190",
+  "weight" : "192",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8777,7 +8789,7 @@
   "name" : "MultiVolumeWorkRelation",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "191",
+  "weight" : "193",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8788,7 +8800,7 @@
   "name" : "OfficialPublication",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "192",
+  "weight" : "194",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8799,7 +8811,7 @@
   "name" : "Schoolbook",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "193",
+  "weight" : "195",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8810,7 +8822,7 @@
   "name" : "SeriesRelation",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "194",
+  "weight" : "196",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8864,7 +8876,7 @@
   "name" : "hasSuperordinate",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "199",
+  "weight" : "201",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8886,7 +8898,7 @@
   "name" : "inCollection",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "200",
+  "weight" : "202",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8981,7 +8993,7 @@
   "name" : "series",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "171",
+  "weight" : "172",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8992,7 +9004,7 @@
   "name" : "subjectAltLabel",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "215",
+  "weight" : "217",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -9014,7 +9026,7 @@
   "name" : "subjectLabel",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "214",
+  "weight" : "216",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19821,7 +19833,7 @@
   "name" : "Article",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
+  "weight" : "235",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19832,7 +19844,7 @@
   "name" : "AudioDocument",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
+  "weight" : "236",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19843,17 +19855,18 @@
   "name" : "bibo:AudioVisual",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
+  "weight" : "256",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Book",
   "comment" : "",
-  "label" : "Buch",
+  "label" : "Monografie",
   "icon" : "fa fa-book",
   "name" : "Book",
+  "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
+  "weight" : "237",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19864,7 +19877,7 @@
   "name" : "Chapter",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
+  "weight" : "238",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19875,7 +19888,7 @@
   "name" : "Collection",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
+  "weight" : "239",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19886,7 +19899,7 @@
   "name" : "DocumentPart",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
+  "weight" : "240",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19897,7 +19910,7 @@
   "name" : "Image",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
+  "weight" : "241",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19908,7 +19921,7 @@
   "name" : "Issue",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
+  "weight" : "242",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19919,7 +19932,7 @@
   "name" : "Journal",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
+  "weight" : "243",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19930,7 +19943,7 @@
   "name" : "Manuscript",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
+  "weight" : "244",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19941,7 +19954,7 @@
   "name" : "Map",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
+  "weight" : "245",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19952,7 +19965,7 @@
   "name" : "MultiVolumeBook",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
+  "weight" : "246",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19963,7 +19976,7 @@
   "name" : "Newspaper",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
+  "weight" : "247",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19974,18 +19987,18 @@
   "name" : "Periodical",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
+  "weight" : "250",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Proceedings",
-  "comment" : "Markdown provides backslash escapes for the following characters:\r\n\r\n    \\   backslash\r\n    `   backtick\r\n    *   asterisk\r\n    _   underscore\r\n    {}  curly braces\r\n    []  square brackets\r\n    ()  parentheses\r\n    #   hash mark\r\n\t+\tplus sign\r\n\t-\tminus sign (hyphen)\r\n    .   dot\r\n    !   exclamation mark\r\n\r\n",
-  "label" : "Konferenzschrift",
+  "comment" : "",
+  "label" : "Kongressschrift",
   "icon" : "octicon octicon-three-bars",
   "name" : "Proceeding",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "2",
+  "weight" : "249",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19996,7 +20009,7 @@
   "name" : "ReferenceSource",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "195",
+  "weight" : "197",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20007,7 +20020,7 @@
   "name" : "Report",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "196",
+  "weight" : "198",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20018,7 +20031,7 @@
   "name" : "Series",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
+  "weight" : "251",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20029,7 +20042,7 @@
   "name" : "Standard",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
+  "weight" : "252",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20040,7 +20053,7 @@
   "name" : "Thesis",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
+  "weight" : "253",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20051,7 +20064,7 @@
   "name" : "volume",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
+  "weight" : "255",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20133,7 +20146,7 @@
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/issn",
-  "comment" : "**HELLO**",
+  "comment" : "",
   "label" : "ISSN",
   "icon" : "",
   "name" : "issn",
@@ -20153,12 +20166,12 @@
 }, {
   "uri" : "http://purl.org/ontology/bibo/oclcnum",
   "comment" : "",
-  "label" : "",
+  "label" : "OCLC Nummer",
   "icon" : "",
   "name" : "oclcNumber",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "",
+  "weight" : "254",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20250,7 +20263,7 @@
   "name" : "Item",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "197",
+  "weight" : "199",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20303,7 +20316,7 @@
   "name" : "predecessor",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "201",
+  "weight" : "203",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20314,7 +20327,7 @@
   "name" : "successor",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "202",
+  "weight" : "204",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20334,7 +20347,7 @@
   "name" : "corporateBodyForTitle",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "203",
+  "weight" : "205",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20378,7 +20391,7 @@
   "name" : "natureOfContent",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "216",
+  "weight" : "218",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20528,7 +20541,7 @@
   "name" : "endDate",
   "referenceType" : "http://www.w3.org/2001/XMLSchema#gYear",
   "container" : "@set",
-  "weight" : "204",
+  "weight" : "206",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20539,7 +20552,7 @@
   "name" : "location",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "205",
+  "weight" : "207",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20561,7 +20574,7 @@
   "name" : "publishedBy",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "212",
+  "weight" : "214",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20572,7 +20585,7 @@
   "name" : "startDate",
   "referenceType" : "http://www.w3.org/2001/XMLSchema#gYear",
   "container" : "@set",
-  "weight" : "206",
+  "weight" : "208",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20703,7 +20716,7 @@
   "name" : "isLike",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "218",
+  "weight" : "220",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20729,7 +20742,7 @@
   "name" : "componentList",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "207",
+  "weight" : "209",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20740,7 +20753,7 @@
   "name" : "itemID",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "222",
+  "weight" : "224",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20767,7 +20780,7 @@
   "label" : "Beschrieben durch",
   "name" : "isDescribedBy",
   "referenceType" : "@id",
-  "weight" : "219",
+  "weight" : "221",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20778,7 +20791,7 @@
   "name" : "similarTo",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "229",
+  "weight" : "231",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20789,7 +20802,7 @@
   "name" : "isLike",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "220",
+  "weight" : "222",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20852,7 +20865,7 @@
   "name" : "sameAs",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "223",
+  "weight" : "225",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20863,7 +20876,7 @@
   "name" : "altLabel",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "208",
+  "weight" : "210",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20883,7 +20896,7 @@
   "name" : "prefLabel",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "170",
+  "weight" : "171",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20902,7 +20915,7 @@
   "label" : "Beschrieben durch",
   "name" : "describedby",
   "referenceType" : "@id",
-  "weight" : "226",
+  "weight" : "228",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20910,7 +20923,7 @@
   "label" : "Gegenstand von",
   "name" : "isPrimaryTopicOf",
   "referenceType" : "@id",
-  "weight" : "227",
+  "weight" : "229",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20921,7 +20934,7 @@
   "name" : "primaryTopic",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "221",
+  "weight" : "223",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -21334,7 +21347,7 @@
   "name" : "joinedFunding",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "181",
+  "weight" : "183",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {

--- a/conf/labels-publisso.de
+++ b/conf/labels-publisso.de
@@ -7961,7 +7961,7 @@
   "comment" : "",
   "label" : "Sonstige",
   "icon" : "",
-  "name" : "Other",
+  "name" : "other",
   "referenceType" : "@id",
   "container" : "",
   "weight" : "248",

--- a/conf/labels-publisso.de
+++ b/conf/labels-publisso.de
@@ -6,7 +6,7 @@
   "name" : "agent",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "10",
+  "weight" : "12",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -17,7 +17,7 @@
   "name" : "contribution",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "12",
+  "weight" : "14",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -28,7 +28,7 @@
   "name" : "role",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "82",
+  "weight" : "85",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -69,7 +69,7 @@
   "name" : "ConferenceOrEvent",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "173",
+  "weight" : "176",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -80,7 +80,7 @@
   "name" : "CorporateBody",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "174",
+  "weight" : "177",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -91,7 +91,7 @@
   "name" : "DifferentiatedPerson",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "175",
+  "weight" : "178",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -102,7 +102,7 @@
   "name" : "Family",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "176",
+  "weight" : "179",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -113,7 +113,7 @@
   "name" : "Person",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "177",
+  "weight" : "180",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -124,7 +124,7 @@
   "name" : "PlaceOrGeographicName",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "178",
+  "weight" : "181",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -135,7 +135,7 @@
   "name" : "SubjectHeading",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "179",
+  "weight" : "182",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -146,7 +146,7 @@
   "name" : "Work",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "180",
+  "weight" : "183",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -157,7 +157,7 @@
   "name" : "dateOfBirth",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "91",
+  "weight" : "94",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -168,7 +168,7 @@
   "name" : "dateOfDeath",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "92",
+  "weight" : "95",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -179,7 +179,7 @@
   "name" : "preferredName",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "93",
+  "weight" : "96",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -187,7 +187,7 @@
   "label" : "",
   "name" : "preferredNameEntityForThePerson",
   "referenceType" : "String",
-  "weight" : "94",
+  "weight" : "97",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -195,7 +195,7 @@
   "label" : "",
   "name" : "preferredNameForTheConferenceOrEvent",
   "referenceType" : "String",
-  "weight" : "95",
+  "weight" : "98",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -206,7 +206,7 @@
   "name" : "preferredNameForTheCorporateBody",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "96",
+  "weight" : "99",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -214,7 +214,7 @@
   "label" : "",
   "name" : "preferredNameForTheFamily",
   "referenceType" : "String",
-  "weight" : "97",
+  "weight" : "100",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -225,7 +225,7 @@
   "name" : "preferredNameForThePerson",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "99",
+  "weight" : "102",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -233,7 +233,7 @@
   "label" : "",
   "name" : "preferredNameForThePlaceOrGeographicName",
   "referenceType" : "String",
-  "weight" : "100",
+  "weight" : "103",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -241,7 +241,7 @@
   "label" : "",
   "name" : "preferredNameForTheSubjectHeading",
   "referenceType" : "String",
-  "weight" : "101",
+  "weight" : "104",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -249,7 +249,7 @@
   "label" : "",
   "name" : "preferredNameForTheWork",
   "referenceType" : "String",
-  "weight" : "102",
+  "weight" : "105",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -260,7 +260,7 @@
   "name" : "gnd:publication",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "45",
+  "weight" : "47",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -278,7 +278,7 @@
   "name" : "institution",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "61",
+  "weight" : "63",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -5859,7 +5859,7 @@
   "name" : "checksum",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "103",
+  "weight" : "106",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -5867,7 +5867,7 @@
   "label" : "",
   "name" : "generator",
   "referenceType" : "@id",
-  "weight" : "104",
+  "weight" : "107",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -5875,7 +5875,7 @@
   "label" : "Größe",
   "name" : "size",
   "referenceType" : "String",
-  "weight" : "105",
+  "weight" : "108",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -5891,7 +5891,7 @@
   "name" : "hasURN",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "77",
+  "weight" : "80",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6122,7 +6122,7 @@
   "name" : "accessScheme",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "216",
+  "weight" : "219",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6133,7 +6133,7 @@
   "name" : "affiliationIndex",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "7",
+  "weight" : "9",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6144,7 +6144,7 @@
   "name" : "agrovoc",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "106",
+  "weight" : "109",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6165,7 +6165,7 @@
   "name" : "articleNumber",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "19",
+  "weight" : "21",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6176,7 +6176,7 @@
   "name" : "associatedDataset",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "29",
+  "weight" : "31",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6187,7 +6187,7 @@
   "name" : "associatedPublication",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "30",
+  "weight" : "32",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6198,7 +6198,7 @@
   "name" : "catalogLink",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "79",
+  "weight" : "82",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6209,7 +6209,7 @@
   "name" : "congressDuration",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "31",
+  "weight" : "33",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6220,7 +6220,7 @@
   "name" : "congressHost",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "17",
+  "weight" : "19",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6231,7 +6231,7 @@
   "name" : "congressLocation",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "32",
+  "weight" : "34",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6242,7 +6242,7 @@
   "name" : "congressNumber",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "18",
+  "weight" : "20",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6253,7 +6253,7 @@
   "name" : "congressShortTitle",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "33",
+  "weight" : "35",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6264,7 +6264,7 @@
   "name" : "congressTitle",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "34",
+  "weight" : "36",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6275,7 +6275,7 @@
   "name" : "contentType",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "208",
+  "weight" : "211",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6283,7 +6283,7 @@
   "label" : "Erstellt von",
   "name" : "createdBy",
   "referenceType" : "String",
-  "weight" : "107",
+  "weight" : "110",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6294,7 +6294,7 @@
   "name" : "dataOrigin",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "108",
+  "weight" : "111",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6305,7 +6305,7 @@
   "name" : "ddc",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "109",
+  "weight" : "112",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6316,7 +6316,7 @@
   "name" : "doi",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "110",
+  "weight" : "113",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6327,7 +6327,7 @@
   "name" : "embargoTime",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "63",
+  "weight" : "66",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6338,7 +6338,7 @@
   "name" : "funding",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "169",
+  "weight" : "172",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6349,7 +6349,7 @@
   "name" : "fundingProgram",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "171",
+  "weight" : "174",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6360,7 +6360,7 @@
   "name" : "hasData",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "111",
+  "weight" : "114",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6371,7 +6371,7 @@
   "name" : "hasTransformer",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "112",
+  "weight" : "115",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6379,7 +6379,7 @@
   "label" : "Import",
   "name" : "importedFrom",
   "referenceType" : "String",
-  "weight" : "113",
+  "weight" : "116",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6390,7 +6390,7 @@
   "name" : "externalParent",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "80",
+  "weight" : "83",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6401,7 +6401,7 @@
   "name" : "issue",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "25",
+  "weight" : "27",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6419,7 +6419,7 @@
   "label" : "Bearbeitet von",
   "name" : "lastModifiedBy",
   "referenceType" : "String",
-  "weight" : "114",
+  "weight" : "117",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6427,7 +6427,7 @@
   "label" : "Id Altsystem",
   "name" : "legacyId",
   "referenceType" : "String",
-  "weight" : "115",
+  "weight" : "118",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6438,7 +6438,7 @@
   "name" : "license",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "64",
+  "weight" : "67",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6446,7 +6446,7 @@
   "label" : "Interner Name",
   "name" : "name",
   "referenceType" : "String",
-  "weight" : "116",
+  "weight" : "119",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6457,7 +6457,7 @@
   "name" : "nextVersion",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "84",
+  "weight" : "87",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6468,7 +6468,7 @@
   "name" : "objectTimestamp",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "117",
+  "weight" : "120",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6489,7 +6489,7 @@
   "name" : "pages",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "41",
+  "weight" : "43",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6500,7 +6500,7 @@
   "name" : "parallelEdition",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "223",
+  "weight" : "226",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6541,7 +6541,7 @@
   "name" : "previousVersion",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "85",
+  "weight" : "88",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6552,7 +6552,7 @@
   "name" : "professionalGroup",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "73",
+  "weight" : "76",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6563,7 +6563,7 @@
   "name" : "projectId",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "170",
+  "weight" : "173",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6574,7 +6574,7 @@
   "name" : "publicationStatus",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "67",
+  "weight" : "70",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6585,7 +6585,7 @@
   "name" : "publicationYear",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "58",
+  "weight" : "60",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6596,7 +6596,7 @@
   "name" : "publishScheme",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "215",
+  "weight" : "218",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6607,7 +6607,7 @@
   "name" : "recordingCoordinates",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "86",
+  "weight" : "89",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6618,7 +6618,7 @@
   "name" : "recordingLocation",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "87",
+  "weight" : "90",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6629,7 +6629,7 @@
   "name" : "recordingPeriod",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "88",
+  "weight" : "91",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6640,7 +6640,7 @@
   "name" : "reference",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "43",
+  "weight" : "45",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6651,7 +6651,7 @@
   "name" : "relatedResource",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "89",
+  "weight" : "92",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6662,7 +6662,7 @@
   "name" : "reviewStatus",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "68",
+  "weight" : "71",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6683,7 +6683,7 @@
   "name" : "titleLanguage",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "9",
+  "weight" : "11",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6694,7 +6694,7 @@
   "name" : "usageManual",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "15",
+  "weight" : "17",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6705,7 +6705,7 @@
   "name" : "volume",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "27",
+  "weight" : "29",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6716,7 +6716,7 @@
   "name" : "volumeIn",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "52",
+  "weight" : "54",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6727,7 +6727,7 @@
   "name" : "yearOfCopyright",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "62",
+  "weight" : "65",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6743,7 +6743,7 @@
   "name" : "agent",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "11",
+  "weight" : "13",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6754,7 +6754,7 @@
   "name" : "contribution",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "13",
+  "weight" : "15",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6765,7 +6765,7 @@
   "name" : "extent",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "204",
+  "weight" : "207",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6776,7 +6776,7 @@
   "name" : "frequency",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "156",
+  "weight" : "159",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6787,7 +6787,7 @@
   "name" : "hasItem",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "222",
+  "weight" : "225",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6798,7 +6798,7 @@
   "name" : "heldBy",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "200",
+  "weight" : "203",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6809,7 +6809,7 @@
   "name" : "itemOf",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "201",
+  "weight" : "204",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6820,7 +6820,7 @@
   "name" : "responsibilityStatement",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "8",
+  "weight" : "10",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6831,7 +6831,7 @@
   "name" : "role",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "83",
+  "weight" : "86",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6842,7 +6842,7 @@
   "name" : "source",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "128",
+  "weight" : "131",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6853,7 +6853,7 @@
   "name" : "supplement",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "202",
+  "weight" : "205",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -7946,7 +7946,7 @@
   "label" : "Gesamttitel",
   "name" : "P1004",
   "referenceType" : "String",
-  "weight" : "118",
+  "weight" : "121",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -7957,7 +7957,7 @@
   "name" : "P1006",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "119",
+  "weight" : "122",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -7968,7 +7968,7 @@
   "name" : "P1016",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "120",
+  "weight" : "123",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -7979,7 +7979,7 @@
   "name" : "P1053",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "40",
+  "weight" : "42",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -7987,7 +7987,7 @@
   "label" : "Kombination",
   "name" : "T1008",
   "referenceType" : "String",
-  "weight" : "121",
+  "weight" : "124",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8197,7 +8197,7 @@
   "name" : "fulltextOnline",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "221",
+  "weight" : "224",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8338,7 +8338,7 @@
   "name" : "contributorName",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "16",
+  "weight" : "18",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8349,7 +8349,7 @@
   "name" : "coverage",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "122",
+  "weight" : "125",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8360,7 +8360,7 @@
   "name" : "creatorName",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "21",
+  "weight" : "23",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8371,7 +8371,7 @@
   "name" : "isPartOfName",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "168",
+  "weight" : "171",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8382,7 +8382,7 @@
   "name" : "publisher",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "74",
+  "weight" : "77",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8393,7 +8393,7 @@
   "name" : "subjectName",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "72",
+  "weight" : "75",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8411,7 +8411,7 @@
   "name" : "abstractText",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "70",
+  "weight" : "73",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8433,7 +8433,7 @@
   "name" : "bibliographicCitation",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "60",
+  "weight" : "62",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8444,7 +8444,7 @@
   "name" : "contributor",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "22",
+  "weight" : "24",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8455,7 +8455,7 @@
   "name" : "created",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "123",
+  "weight" : "126",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8466,7 +8466,7 @@
   "name" : "creator",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "20",
+  "weight" : "22",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8475,7 +8475,7 @@
   "name" : "description",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "124",
+  "weight" : "127",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8483,7 +8483,7 @@
   "label" : "Format",
   "name" : "format",
   "referenceType" : "String",
-  "weight" : "125",
+  "weight" : "128",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8492,7 +8492,7 @@
   "name" : "hasFormat",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "126",
+  "weight" : "129",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8503,7 +8503,7 @@
   "name" : "hasPart",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "172",
+  "weight" : "175",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8514,7 +8514,7 @@
   "name" : "hasVersion",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "219",
+  "weight" : "222",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8525,7 +8525,7 @@
   "name" : "primaryForm",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "189",
+  "weight" : "192",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8536,7 +8536,7 @@
   "name" : "parentPid",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "81",
+  "weight" : "84",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8547,7 +8547,7 @@
   "name" : "issued",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "48",
+  "weight" : "50",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8558,7 +8558,7 @@
   "name" : "language",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "69",
+  "weight" : "72",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8569,7 +8569,7 @@
   "name" : "medium",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "56",
+  "weight" : "58",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8580,7 +8580,7 @@
   "name" : "modified",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "127",
+  "weight" : "130",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8591,7 +8591,7 @@
   "name" : "source",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "129",
+  "weight" : "132",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8602,7 +8602,7 @@
   "name" : "spatial",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "130",
+  "weight" : "133",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8613,7 +8613,7 @@
   "name" : "subject",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "71",
+  "weight" : "74",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8624,7 +8624,7 @@
   "name" : "tableOfContents",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "131",
+  "weight" : "134",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8660,7 +8660,7 @@
   "name" : "Game",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "181",
+  "weight" : "184",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8723,7 +8723,7 @@
   "name" : "MultiVolumeWorkRelation",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "182",
+  "weight" : "185",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8734,7 +8734,7 @@
   "name" : "OfficialPublication",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "183",
+  "weight" : "186",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8745,7 +8745,7 @@
   "name" : "Schoolbook",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "184",
+  "weight" : "187",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8756,7 +8756,7 @@
   "name" : "SeriesRelation",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "185",
+  "weight" : "188",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8777,7 +8777,7 @@
   "name" : "containedIn",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "59",
+  "weight" : "61",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8788,7 +8788,7 @@
   "name" : "contributorOrder",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "132",
+  "weight" : "135",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8799,7 +8799,7 @@
   "name" : "fulltextOnline",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "133",
+  "weight" : "136",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8810,7 +8810,7 @@
   "name" : "hasSuperordinate",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "190",
+  "weight" : "193",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8821,7 +8821,7 @@
   "name" : "hbzId",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "35",
+  "weight" : "37",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8832,7 +8832,7 @@
   "name" : "inCollection",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "191",
+  "weight" : "194",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8843,7 +8843,7 @@
   "name" : "inSeries",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "51",
+  "weight" : "53",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8854,7 +8854,7 @@
   "name" : "lv:isPartOf",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "55",
+  "weight" : "57",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8863,7 +8863,7 @@
   "name" : "multiVolumeWork",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "134",
+  "weight" : "137",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8872,7 +8872,7 @@
   "name" : "contributingCorporateBodyLabel",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "135",
+  "weight" : "138",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8883,7 +8883,7 @@
   "name" : "numbering",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "136",
+  "weight" : "139",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8894,7 +8894,7 @@
   "name" : "nwbibspatial",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "137",
+  "weight" : "140",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8905,7 +8905,7 @@
   "name" : "nwbibsubject",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "138",
+  "weight" : "141",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8916,7 +8916,7 @@
   "name" : "rpbSubject",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "36",
+  "weight" : "38",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8927,7 +8927,7 @@
   "name" : "series",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "167",
+  "weight" : "170",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8938,7 +8938,7 @@
   "name" : "subjectAltLabel",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "206",
+  "weight" : "209",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8949,7 +8949,7 @@
   "name" : "subjectChain",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "98",
+  "weight" : "101",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8960,7 +8960,7 @@
   "name" : "subjectLabel",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "205",
+  "weight" : "208",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8969,7 +8969,7 @@
   "name" : "subjectLocation",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "139",
+  "weight" : "142",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8980,7 +8980,7 @@
   "name" : "subjectOrder",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "140",
+  "weight" : "143",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8991,7 +8991,7 @@
   "name" : "titleKeyword",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "90",
+  "weight" : "93",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -9002,7 +9002,7 @@
   "name" : "urn",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "78",
+  "weight" : "81",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -9013,7 +9013,7 @@
   "name" : "lv:volumeIn",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "53",
+  "weight" : "55",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -9022,7 +9022,7 @@
   "name" : "webPageArchived",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "5",
+  "weight" : "7",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -9033,7 +9033,7 @@
   "name" : "zdbId",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "39",
+  "weight" : "41",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19797,6 +19797,16 @@
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
+  "uri" : "http://purl.org/ontology/bibo/Chapter",
+  "comment" : "",
+  "label" : "Kapitel",
+  "icon" : "",
+  "name" : "Chapter",
+  "container" : "",
+  "weight" : "",
+  "type" : "STORE",
+  "multilangLabel" : { }
+}, {
   "uri" : "http://purl.org/ontology/bibo/Collection",
   "label" : "Sammlung",
   "icon" : "glyphicon glyphicon-th-large",
@@ -19894,7 +19904,7 @@
   "name" : "ReferenceSource",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "186",
+  "weight" : "189",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19905,7 +19915,7 @@
   "name" : "Report",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "187",
+  "weight" : "190",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19950,7 +19960,7 @@
   "name" : "bibo:doi",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "75",
+  "weight" : "78",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19961,7 +19971,7 @@
   "name" : "edition",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "26",
+  "weight" : "28",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19972,7 +19982,7 @@
   "name" : "editor",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "141",
+  "weight" : "144",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19983,7 +19993,7 @@
   "name" : "eissn",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "37",
+  "weight" : "39",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19994,7 +20004,7 @@
   "name" : "Isbn",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "142",
+  "weight" : "145",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20005,7 +20015,7 @@
   "name" : "isbn",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "143",
+  "weight" : "146",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20016,7 +20026,7 @@
   "name" : "isbn13",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "144",
+  "weight" : "147",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20027,7 +20037,7 @@
   "name" : "issn",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "38",
+  "weight" : "40",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20035,7 +20045,7 @@
   "label" : "Lccn",
   "name" : "lccn",
   "referenceType" : "String",
-  "weight" : "145",
+  "weight" : "148",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20056,7 +20066,7 @@
   "name" : "shortTitle",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "23",
+  "weight" : "25",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20067,7 +20077,7 @@
   "name" : "translator",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "24",
+  "weight" : "26",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20078,7 +20088,7 @@
   "name" : "callNumber",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "146",
+  "weight" : "149",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20089,7 +20099,7 @@
   "name" : "collectedBy",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "147",
+  "weight" : "150",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20115,7 +20125,7 @@
   "name" : "ismn",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "148",
+  "weight" : "151",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20126,7 +20136,7 @@
   "name" : "wikipedia",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "149",
+  "weight" : "152",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20137,7 +20147,7 @@
   "name" : "Item",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "188",
+  "weight" : "191",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20152,7 +20162,7 @@
   "label" : "Exemplar",
   "name" : "exemplar",
   "referenceType" : "String",
-  "weight" : "150",
+  "weight" : "153",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20161,7 +20171,7 @@
   "name" : "exemplarOf",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "151",
+  "weight" : "154",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20170,7 +20180,7 @@
   "name" : "owner",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "152",
+  "weight" : "155",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20179,7 +20189,7 @@
   "name" : "isSupplementTo",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "153",
+  "weight" : "156",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20190,7 +20200,7 @@
   "name" : "predecessor",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "192",
+  "weight" : "195",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20201,7 +20211,7 @@
   "name" : "successor",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "193",
+  "weight" : "196",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20210,7 +20220,7 @@
   "name" : "hasSupplement",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "154",
+  "weight" : "157",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20221,7 +20231,7 @@
   "name" : "corporateBodyForTitle",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "194",
+  "weight" : "197",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20232,7 +20242,7 @@
   "name" : "P60489",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "155",
+  "weight" : "158",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20247,6 +20257,17 @@
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
+  "uri" : "http://rdaregistry.info/Elements/u/P60517",
+  "comment" : "",
+  "label" : "Unterreihe",
+  "icon" : "",
+  "name" : "titleOfSubSeries",
+  "referenceType" : "String",
+  "container" : "",
+  "weight" : "6",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
   "uri" : "http://rdaregistry.info/Elements/u/P60584",
   "comment" : "",
   "label" : "Formschlagwörter",
@@ -20254,7 +20275,7 @@
   "name" : "natureOfContent",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "207",
+  "weight" : "210",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20288,7 +20309,7 @@
   "name" : "frequency",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "157",
+  "weight" : "160",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20297,7 +20318,18 @@
   "name" : "longitudeAndLatitude",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "158",
+  "weight" : "161",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
+  "uri" : "http://rdvocab.info/Elements/otherTitleInformation",
+  "comment" : "",
+  "label" : "Titelzusatz weitere",
+  "icon" : "",
+  "name" : "otherTitleInformation",
+  "referenceType" : "String",
+  "container" : "@set",
+  "weight" : "5",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20308,7 +20340,7 @@
   "name" : "placeOfPublication",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "28",
+  "weight" : "30",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20319,7 +20351,7 @@
   "name" : "publicationStatement",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "42",
+  "weight" : "44",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20330,7 +20362,7 @@
   "name" : "statementOfResponsibility",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "50",
+  "weight" : "52",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20341,7 +20373,7 @@
   "name" : "workManifested",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "159",
+  "weight" : "162",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20393,7 +20425,7 @@
   "name" : "endDate",
   "referenceType" : "http://www.w3.org/2001/XMLSchema#gYear",
   "container" : "@set",
-  "weight" : "195",
+  "weight" : "198",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20404,7 +20436,7 @@
   "name" : "location",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "196",
+  "weight" : "199",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20415,7 +20447,7 @@
   "name" : "publication",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "44",
+  "weight" : "46",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20426,7 +20458,7 @@
   "name" : "publishedBy",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "203",
+  "weight" : "206",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20437,7 +20469,7 @@
   "name" : "startDate",
   "referenceType" : "http://www.w3.org/2001/XMLSchema#gYear",
   "container" : "@set",
-  "weight" : "197",
+  "weight" : "200",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20568,7 +20600,7 @@
   "name" : "isLike",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "209",
+  "weight" : "212",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20594,7 +20626,7 @@
   "name" : "componentList",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "198",
+  "weight" : "201",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20605,7 +20637,7 @@
   "name" : "itemID",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "213",
+  "weight" : "216",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20613,7 +20645,7 @@
   "label" : "beschreibt",
   "name" : "describes",
   "referenceType" : "@id",
-  "weight" : "160",
+  "weight" : "163",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20624,7 +20656,7 @@
   "name" : "isAggregatedBy",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "161",
+  "weight" : "164",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20632,7 +20664,7 @@
   "label" : "Beschrieben durch",
   "name" : "isDescribedBy",
   "referenceType" : "@id",
-  "weight" : "210",
+  "weight" : "213",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20643,7 +20675,7 @@
   "name" : "similarTo",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "220",
+  "weight" : "223",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20654,7 +20686,7 @@
   "name" : "isLike",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "211",
+  "weight" : "214",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20665,7 +20697,7 @@
   "name" : "rdftype",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "57",
+  "weight" : "59",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20673,7 +20705,7 @@
   "label" : "",
   "name" : "inDataset",
   "referenceType" : "String",
-  "weight" : "162",
+  "weight" : "165",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20684,7 +20716,7 @@
   "name" : "label",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "6",
+  "weight" : "8",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20695,7 +20727,7 @@
   "name" : "seeAlso",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "163",
+  "weight" : "166",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20706,7 +20738,7 @@
   "name" : "xsd",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "164",
+  "weight" : "167",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20717,7 +20749,7 @@
   "name" : "sameAs",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "214",
+  "weight" : "217",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20728,7 +20760,7 @@
   "name" : "altLabel",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "199",
+  "weight" : "202",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20737,7 +20769,7 @@
   "name" : "note",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "165",
+  "weight" : "168",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20748,7 +20780,7 @@
   "name" : "prefLabel",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "166",
+  "weight" : "169",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20759,7 +20791,7 @@
   "name" : "affiliation",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "14",
+  "weight" : "16",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20767,7 +20799,7 @@
   "label" : "Beschrieben durch",
   "name" : "describedby",
   "referenceType" : "@id",
-  "weight" : "217",
+  "weight" : "220",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20775,7 +20807,7 @@
   "label" : "Gegenstand von",
   "name" : "isPrimaryTopicOf",
   "referenceType" : "@id",
-  "weight" : "218",
+  "weight" : "221",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20786,7 +20818,7 @@
   "name" : "primaryTopic",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "212",
+  "weight" : "215",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20803,6 +20835,16 @@
   "uri" : "https://creativecommons.org/licenses/by/4.0",
   "comment" : "",
   "label" : "CC BY 4.0",
+  "icon" : "",
+  "name" : "",
+  "container" : "",
+  "weight" : "",
+  "type" : "STORE",
+  "multilangLabel" : { }
+}, {
+  "uri" : "https://creativecommons.org/publicdomain/zero/1.0/",
+  "comment" : "",
+  "label" : "CC0 1.0",
   "icon" : "",
   "name" : "",
   "container" : "",
@@ -21189,7 +21231,7 @@
   "name" : "regal:publishLocation",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "46",
+  "weight" : "48",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -21200,7 +21242,7 @@
   "name" : "regal:publishYear",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "48",
+  "weight" : "51",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -21211,7 +21253,7 @@
   "name" : "regal:publishedBy",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "47",
+  "weight" : "49",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -21232,7 +21274,7 @@
   "name" : "additionalMaterial",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "66",
+  "weight" : "69",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -21259,7 +21301,18 @@
   "name" : "collectionOne",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "54",
+  "weight" : "56",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
+  "uri" : "info:regal/zettel/collectionTwo",
+  "comment" : "",
+  "label" : "Übergeordneter Kongress ",
+  "icon" : "",
+  "name" : "collectionTwo",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "64",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -21286,7 +21339,7 @@
   "name" : "fulltextVersion",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "76",
+  "weight" : "79",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -21630,7 +21683,7 @@
   "name" : "publisherVersion",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "65",
+  "weight" : "68",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -21660,13 +21713,19 @@
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
+  "uri" : "info:regal/zettel/typeHeader",
+  "label" : "Publikationstyp",
+  "referenceType" : "String",
+  "type" : "STORE",
+  "multilangLabel" : { }
+}, {
   "uri" : "info:regal/zettel/uploadHeader",
   "label" : "Dateiupload",
   "referenceType" : "String",
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
-  "uri" : "https://creativecommons.org/publicdomain/zero/1.0/",
+  "uri" : "ttps://creativecommons.org/publicdomain/zero/1.0/",
   "comment" : "",
   "label" : "CC0 1.0",
   "icon" : "",
@@ -21675,17 +21734,4 @@
   "weight" : "",
   "type" : "STORE",
   "multilangLabel" : { }
-}, {
-  "uri" : "info:regal/zettel/typeHeader",
-  "label" : "Publikationstyp",
-  "referenceType" : "String",
-  "type" : "STORE",
-  "multilangLabel" : { }
-}, {
-  "uri" : "http://purl.org/ontology/bibo/Chapter",
-  "type" : "STORE",
-  "multilangLabel" : { }
-}
-
-
-]
+} ]

--- a/conf/labels-publisso.de
+++ b/conf/labels-publisso.de
@@ -6342,23 +6342,12 @@
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
-  "uri" : "http://hbz-nrw.de/regal#fundingId",
-  "comment" : "",
-  "label" : "Förderer",
-  "icon" : "fa fa-bars",
-  "name" : "fundingId",
-  "referenceType" : "@id",
-  "container" : "@list",
-  "weight" : "173",
-  "type" : "CONTEXT",
-  "multilangLabel" : { }
-}, {
   "uri" : "http://hbz-nrw.de/regal#fundingJoined",
   "comment" : "",
   "label" : "Förderer",
   "icon" : "",
   "name" : "fundingJoined",
-  "referenceType" : "@id",
+  "referenceType" : "String",
   "container" : "",
   "weight" : "174",
   "type" : "CONTEXT",
@@ -19863,7 +19852,6 @@
   "label" : "Buch",
   "icon" : "fa fa-book",
   "name" : "Book",
-  "referenceType" : "@id",
   "container" : "",
   "weight" : "",
   "type" : "CONTEXT",

--- a/conf/labels-publisso.de
+++ b/conf/labels-publisso.de
@@ -273,7 +273,7 @@
 }, {
   "uri" : "http://dbpedia.org/ontology/institution",
   "comment" : "",
-  "label" : "Sammlungszuordnung",
+  "label" : "Sammlung",
   "icon" : "",
   "name" : "institution",
   "referenceType" : "@id",
@@ -393,7 +393,7 @@
   "multilangLabel" : { }
 }, {
   "uri" : "http://dewey.info/class/018/",
-  "label" : "Kataloge nach Autor, Erscheinungsjahr usw.",
+  "label" : "Kataloge nach Autor/in, Erscheinungsjahr usw.",
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
@@ -7768,7 +7768,7 @@
   "multilangLabel" : { }
 }, {
   "uri" : "http://id.loc.gov/vocabulary/relators/aft",
-  "label" : "Autor des Nachwortes",
+  "label" : "Autor/in des Nachwortes",
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
@@ -7823,7 +7823,7 @@
   "multilangLabel" : { }
 }, {
   "uri" : "http://id.loc.gov/vocabulary/relators/ctb",
-  "label" : "Mitwirkende",
+  "label" : "Mitwirkende/r",
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
@@ -8333,7 +8333,7 @@
 }, {
   "uri" : "http://purl.org/dc/elements/1.1/contributor",
   "comment" : "",
-  "label" : "Mitwirkende",
+  "label" : "Mitwirkende/r",
   "icon" : "",
   "name" : "contributorName",
   "referenceType" : "String",
@@ -8355,7 +8355,7 @@
 }, {
   "uri" : "http://purl.org/dc/elements/1.1/creator",
   "comment" : "",
-  "label" : "Autor",
+  "label" : "Autor/in",
   "icon" : "",
   "name" : "creatorName",
   "referenceType" : "String",
@@ -8406,7 +8406,7 @@
 }, {
   "uri" : "http://purl.org/dc/terms/abstract",
   "comment" : "",
-  "label" : "Zusammenfassung",
+  "label" : "Abstract/Summary",
   "icon" : "",
   "name" : "abstractText",
   "referenceType" : "String",
@@ -8439,7 +8439,7 @@
 }, {
   "uri" : "http://purl.org/dc/terms/contributor",
   "comment" : "",
-  "label" : "Mitwirkende",
+  "label" : "Mitwirkende/r",
   "icon" : "",
   "name" : "contributor",
   "referenceType" : "@id",
@@ -8461,7 +8461,7 @@
 }, {
   "uri" : "http://purl.org/dc/terms/creator",
   "comment" : "",
-  "label" : "Autor",
+  "label" : "Autor/in",
   "icon" : "",
   "name" : "creator",
   "referenceType" : "@id",
@@ -8933,7 +8933,7 @@
 }, {
   "uri" : "http://purl.org/lobid/lv#subjectAltLabel",
   "comment" : "",
-  "label" : "Freie Schlagwörter",
+  "label" : "Schlagwörter",
   "icon" : "",
   "name" : "subjectAltLabel",
   "referenceType" : "String",
@@ -13079,12 +13079,12 @@
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/lobid/nwbib#s768010",
-  "label" : "Einzelne Autoren (Primärliteratur)",
+  "label" : "Einzelne AutorInnen (Primärliteratur)",
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/lobid/nwbib#s768030",
-  "label" : "Einzelne Autoren (Sekundärliteratur)",
+  "label" : "Einzelne AutorInnen (Sekundärliteratur)",
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
@@ -19967,7 +19967,7 @@
 }, {
   "uri" : "http://purl.org/ontology/bibo/editor",
   "comment" : "",
-  "label" : "Herausgeber",
+  "label" : "Herausgeber/in",
   "icon" : "",
   "name" : "editor",
   "referenceType" : "@id",
@@ -21254,7 +21254,7 @@
 }, {
   "uri" : "info:regal/zettel/collectionOne",
   "comment" : "",
-  "label" : "Leibniz Organisation",
+  "label" : "LeibnizOpen",
   "icon" : "",
   "name" : "collectionOne",
   "referenceType" : "@id",
@@ -21666,7 +21666,7 @@
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
-  "uri" : "ttps://creativecommons.org/publicdomain/zero/1.0/",
+  "uri" : "https://creativecommons.org/publicdomain/zero/1.0/",
   "comment" : "",
   "label" : "CC0 1.0",
   "icon" : "",
@@ -21675,4 +21675,17 @@
   "weight" : "",
   "type" : "STORE",
   "multilangLabel" : { }
-} ]
+}, {
+  "uri" : "info:regal/zettel/typeHeader",
+  "label" : "Publikationstyp",
+  "referenceType" : "String",
+  "type" : "STORE",
+  "multilangLabel" : { }
+}, {
+  "uri" : "http://purl.org/ontology/bibo/Chapter",
+  "type" : "STORE",
+  "multilangLabel" : { }
+}
+
+
+]

--- a/conf/labels-publisso.de
+++ b/conf/labels-publisso.de
@@ -6342,12 +6342,23 @@
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
+  "uri" : "http://hbz-nrw.de/regal#fundingId",
+  "comment" : "",
+  "label" : "Förderer",
+  "icon" : "fa fa-bars",
+  "name" : "fundingId",
+  "referenceType" : "@id",
+  "container" : "@list",
+  "weight" : "173",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
   "uri" : "http://hbz-nrw.de/regal#fundingJoined",
   "comment" : "",
   "label" : "Förderer",
   "icon" : "",
   "name" : "fundingJoined",
-  "referenceType" : "String",
+  "referenceType" : "@id",
   "container" : "",
   "weight" : "174",
   "type" : "CONTEXT",

--- a/conf/labels.json
+++ b/conf/labels.json
@@ -28,7 +28,7 @@
   "name" : "role",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "85",
+  "weight" : "86",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -69,7 +69,7 @@
   "name" : "ConferenceOrEvent",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "176",
+  "weight" : "184",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -80,7 +80,7 @@
   "name" : "CorporateBody",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "177",
+  "weight" : "185",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -91,7 +91,7 @@
   "name" : "DifferentiatedPerson",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "178",
+  "weight" : "186",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -102,7 +102,7 @@
   "name" : "Family",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "179",
+  "weight" : "187",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -113,7 +113,7 @@
   "name" : "Person",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "180",
+  "weight" : "188",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -124,7 +124,7 @@
   "name" : "PlaceOrGeographicName",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "181",
+  "weight" : "189",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -135,7 +135,7 @@
   "name" : "SubjectHeading",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "182",
+  "weight" : "190",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -146,7 +146,7 @@
   "name" : "Work",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "183",
+  "weight" : "191",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -157,7 +157,7 @@
   "name" : "dateOfBirth",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "94",
+  "weight" : "95",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -168,7 +168,7 @@
   "name" : "dateOfDeath",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "95",
+  "weight" : "96",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -179,7 +179,7 @@
   "name" : "preferredName",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "96",
+  "weight" : "97",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -187,7 +187,7 @@
   "label" : "",
   "name" : "preferredNameEntityForThePerson",
   "referenceType" : "String",
-  "weight" : "97",
+  "weight" : "98",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -195,7 +195,7 @@
   "label" : "",
   "name" : "preferredNameForTheConferenceOrEvent",
   "referenceType" : "String",
-  "weight" : "98",
+  "weight" : "99",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -206,7 +206,7 @@
   "name" : "preferredNameForTheCorporateBody",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "99",
+  "weight" : "100",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -214,7 +214,7 @@
   "label" : "",
   "name" : "preferredNameForTheFamily",
   "referenceType" : "String",
-  "weight" : "100",
+  "weight" : "101",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -225,7 +225,7 @@
   "name" : "preferredNameForThePerson",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "102",
+  "weight" : "103",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -233,7 +233,7 @@
   "label" : "",
   "name" : "preferredNameForThePlaceOrGeographicName",
   "referenceType" : "String",
-  "weight" : "103",
+  "weight" : "104",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -241,7 +241,7 @@
   "label" : "",
   "name" : "preferredNameForTheSubjectHeading",
   "referenceType" : "String",
-  "weight" : "104",
+  "weight" : "105",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -249,7 +249,7 @@
   "label" : "",
   "name" : "preferredNameForTheWork",
   "referenceType" : "String",
-  "weight" : "105",
+  "weight" : "106",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -273,7 +273,7 @@
 }, {
   "uri" : "http://dbpedia.org/ontology/institution",
   "comment" : "",
-  "label" : "Sammlung",
+  "label" : "FRL-Sammlung",
   "icon" : "",
   "name" : "institution",
   "referenceType" : "@id",
@@ -5859,7 +5859,7 @@
   "name" : "checksum",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "106",
+  "weight" : "107",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -5867,7 +5867,7 @@
   "label" : "",
   "name" : "generator",
   "referenceType" : "@id",
-  "weight" : "107",
+  "weight" : "108",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -5875,7 +5875,7 @@
   "label" : "Größe",
   "name" : "size",
   "referenceType" : "String",
-  "weight" : "108",
+  "weight" : "109",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -5891,7 +5891,7 @@
   "name" : "hasURN",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "80",
+  "weight" : "81",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6122,7 +6122,7 @@
   "name" : "accessScheme",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "219",
+  "weight" : "227",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6144,7 +6144,7 @@
   "name" : "agrovoc",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "109",
+  "weight" : "110",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6159,7 +6159,7 @@
   "multilangLabel" : { }
 }, {
   "uri" : "http://hbz-nrw.de/regal#articleNumber",
-  "comment" : "**HELLO**",
+  "comment" : "",
   "label" : "Artikelnummer",
   "icon" : "",
   "name" : "articleNumber",
@@ -6198,7 +6198,7 @@
   "name" : "catalogLink",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "82",
+  "weight" : "83",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6275,7 +6275,7 @@
   "name" : "contentType",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "211",
+  "weight" : "219",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6283,7 +6283,7 @@
   "label" : "Erstellt von",
   "name" : "createdBy",
   "referenceType" : "String",
-  "weight" : "110",
+  "weight" : "111",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6294,7 +6294,7 @@
   "name" : "dataOrigin",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "111",
+  "weight" : "112",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6305,7 +6305,7 @@
   "name" : "ddc",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "112",
+  "weight" : "113",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6316,7 +6316,7 @@
   "name" : "doi",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "113",
+  "weight" : "114",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6338,7 +6338,29 @@
   "name" : "funding",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "172",
+  "weight" : "174",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
+  "uri" : "http://hbz-nrw.de/regal#fundingId",
+  "comment" : "",
+  "label" : "Förderer",
+  "icon" : "",
+  "name" : "fundingId",
+  "referenceType" : "@id",
+  "container" : "@list",
+  "weight" : "175",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
+  "uri" : "http://hbz-nrw.de/regal#fundingJoined",
+  "comment" : "",
+  "label" : "Förderer",
+  "icon" : "",
+  "name" : "fundingJoined",
+  "referenceType" : "String",
+  "container" : "",
+  "weight" : "176",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6349,7 +6371,18 @@
   "name" : "fundingProgram",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "174",
+  "weight" : "180",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
+  "uri" : "http://hbz-nrw.de/regal#fundingProgramJoined",
+  "comment" : "",
+  "label" : "Förderprogramm",
+  "icon" : "",
+  "name" : "fundingProgramJoined",
+  "referenceType" : "String",
+  "container" : "",
+  "weight" : "181",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6360,7 +6393,7 @@
   "name" : "hasData",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "114",
+  "weight" : "115",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6371,7 +6404,7 @@
   "name" : "hasTransformer",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "115",
+  "weight" : "116",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6379,7 +6412,7 @@
   "label" : "Import",
   "name" : "importedFrom",
   "referenceType" : "String",
-  "weight" : "116",
+  "weight" : "117",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6390,7 +6423,7 @@
   "name" : "externalParent",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "83",
+  "weight" : "84",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6419,7 +6452,7 @@
   "label" : "Bearbeitet von",
   "name" : "lastModifiedBy",
   "referenceType" : "String",
-  "weight" : "117",
+  "weight" : "118",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6427,7 +6460,7 @@
   "label" : "Id Altsystem",
   "name" : "legacyId",
   "referenceType" : "String",
-  "weight" : "118",
+  "weight" : "119",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6446,7 +6479,7 @@
   "label" : "Interner Name",
   "name" : "name",
   "referenceType" : "String",
-  "weight" : "119",
+  "weight" : "120",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6457,7 +6490,7 @@
   "name" : "nextVersion",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "87",
+  "weight" : "88",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6468,7 +6501,7 @@
   "name" : "objectTimestamp",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "120",
+  "weight" : "121",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6483,7 +6516,7 @@
   "multilangLabel" : { }
 }, {
   "uri" : "http://hbz-nrw.de/regal#pages",
-  "comment" : "**HELLO**",
+  "comment" : "",
   "label" : "Seiten",
   "icon" : "",
   "name" : "pages",
@@ -6500,7 +6533,7 @@
   "name" : "parallelEdition",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "226",
+  "weight" : "234",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6541,7 +6574,7 @@
   "name" : "previousVersion",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "88",
+  "weight" : "89",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6552,7 +6585,7 @@
   "name" : "professionalGroup",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "76",
+  "weight" : "77",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6563,18 +6596,40 @@
   "name" : "projectId",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "173",
+  "weight" : "177",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
+  "uri" : "http://hbz-nrw.de/regal#projectIdJoin",
+  "comment" : "",
+  "label" : "Fördernummer",
+  "icon" : "",
+  "name" : "projectIdJoin",
+  "referenceType" : "String",
+  "container" : "",
+  "weight" : "178",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
+  "uri" : "http://hbz-nrw.de/regal#projectIdJoined",
+  "comment" : "",
+  "label" : "Fördernummer",
+  "icon" : "",
+  "name" : "projectIdJoined",
+  "referenceType" : "String",
+  "container" : "",
+  "weight" : "179",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://hbz-nrw.de/regal#publicationStatus",
-  "comment" : "**HELLO**",
+  "comment" : "",
   "label" : "Publikationsstatus",
   "icon" : "",
   "name" : "publicationStatus",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "70",
+  "weight" : "71",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6596,7 +6651,7 @@
   "name" : "publishScheme",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "218",
+  "weight" : "226",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6607,7 +6662,7 @@
   "name" : "recordingCoordinates",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "89",
+  "weight" : "90",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6618,7 +6673,7 @@
   "name" : "recordingLocation",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "90",
+  "weight" : "91",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6629,7 +6684,7 @@
   "name" : "recordingPeriod",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "91",
+  "weight" : "92",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6651,7 +6706,7 @@
   "name" : "relatedResource",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "92",
+  "weight" : "93",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6662,7 +6717,7 @@
   "name" : "reviewStatus",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "71",
+  "weight" : "72",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6699,7 +6754,7 @@
   "multilangLabel" : { }
 }, {
   "uri" : "http://hbz-nrw.de/regal#volume",
-  "comment" : "**HELLO**",
+  "comment" : "",
   "label" : "Band",
   "icon" : "",
   "name" : "volume",
@@ -6765,7 +6820,7 @@
   "name" : "extent",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "207",
+  "weight" : "215",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6776,7 +6831,7 @@
   "name" : "frequency",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "159",
+  "weight" : "160",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6787,7 +6842,7 @@
   "name" : "hasItem",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "225",
+  "weight" : "233",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6798,7 +6853,7 @@
   "name" : "heldBy",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "203",
+  "weight" : "211",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6809,7 +6864,7 @@
   "name" : "itemOf",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "204",
+  "weight" : "212",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6831,7 +6886,7 @@
   "name" : "role",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "86",
+  "weight" : "87",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6842,7 +6897,7 @@
   "name" : "source",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "131",
+  "weight" : "132",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6853,7 +6908,7 @@
   "name" : "supplement",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "205",
+  "weight" : "213",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -7902,6 +7957,17 @@
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
+  "uri" : "http://id.loc.gov/vocabulary/relators/oth",
+  "comment" : "",
+  "label" : "Sonstige",
+  "icon" : "",
+  "name" : "other",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "248",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
   "uri" : "http://id.loc.gov/vocabulary/relators/pht",
   "label" : "Fotografie",
   "type" : "STORE",
@@ -7946,7 +8012,7 @@
   "label" : "Gesamttitel",
   "name" : "P1004",
   "referenceType" : "String",
-  "weight" : "121",
+  "weight" : "122",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -7957,7 +8023,7 @@
   "name" : "P1006",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "122",
+  "weight" : "123",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -7968,7 +8034,7 @@
   "name" : "P1016",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "123",
+  "weight" : "124",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -7987,7 +8053,7 @@
   "label" : "Kombination",
   "name" : "T1008",
   "referenceType" : "String",
-  "weight" : "124",
+  "weight" : "125",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8197,7 +8263,7 @@
   "name" : "fulltextOnline",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "224",
+  "weight" : "232",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8349,7 +8415,7 @@
   "name" : "coverage",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "125",
+  "weight" : "126",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8371,7 +8437,7 @@
   "name" : "isPartOfName",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "171",
+  "weight" : "173",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8382,7 +8448,7 @@
   "name" : "publisher",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "77",
+  "weight" : "78",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8393,7 +8459,7 @@
   "name" : "subjectName",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "75",
+  "weight" : "76",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8411,7 +8477,7 @@
   "name" : "abstractText",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "73",
+  "weight" : "74",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8455,7 +8521,7 @@
   "name" : "created",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "126",
+  "weight" : "127",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8475,7 +8541,7 @@
   "name" : "description",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "127",
+  "weight" : "128",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8483,7 +8549,7 @@
   "label" : "Format",
   "name" : "format",
   "referenceType" : "String",
-  "weight" : "128",
+  "weight" : "129",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8492,7 +8558,7 @@
   "name" : "hasFormat",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "129",
+  "weight" : "130",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8503,7 +8569,7 @@
   "name" : "hasPart",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "175",
+  "weight" : "182",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8514,7 +8580,7 @@
   "name" : "hasVersion",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "222",
+  "weight" : "230",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8525,7 +8591,7 @@
   "name" : "primaryForm",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "192",
+  "weight" : "200",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8536,7 +8602,7 @@
   "name" : "parentPid",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "84",
+  "weight" : "85",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8558,7 +8624,7 @@
   "name" : "language",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "72",
+  "weight" : "73",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8580,7 +8646,7 @@
   "name" : "modified",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "130",
+  "weight" : "131",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8591,7 +8657,7 @@
   "name" : "source",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "132",
+  "weight" : "133",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8602,7 +8668,7 @@
   "name" : "spatial",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "133",
+  "weight" : "134",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8613,7 +8679,7 @@
   "name" : "subject",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "74",
+  "weight" : "75",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8624,7 +8690,7 @@
   "name" : "tableOfContents",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "134",
+  "weight" : "135",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8660,7 +8726,7 @@
   "name" : "Game",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "184",
+  "weight" : "192",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8723,7 +8789,7 @@
   "name" : "MultiVolumeWorkRelation",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "185",
+  "weight" : "193",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8734,7 +8800,7 @@
   "name" : "OfficialPublication",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "186",
+  "weight" : "194",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8745,7 +8811,7 @@
   "name" : "Schoolbook",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "187",
+  "weight" : "195",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8756,7 +8822,7 @@
   "name" : "SeriesRelation",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "188",
+  "weight" : "196",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8788,7 +8854,7 @@
   "name" : "contributorOrder",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "135",
+  "weight" : "136",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8799,7 +8865,7 @@
   "name" : "fulltextOnline",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "136",
+  "weight" : "137",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8810,7 +8876,7 @@
   "name" : "hasSuperordinate",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "193",
+  "weight" : "201",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8832,7 +8898,7 @@
   "name" : "inCollection",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "194",
+  "weight" : "202",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8863,7 +8929,7 @@
   "name" : "multiVolumeWork",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "137",
+  "weight" : "138",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8872,7 +8938,7 @@
   "name" : "contributingCorporateBodyLabel",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "138",
+  "weight" : "139",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8883,7 +8949,7 @@
   "name" : "numbering",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "139",
+  "weight" : "140",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8894,7 +8960,7 @@
   "name" : "nwbibspatial",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "140",
+  "weight" : "141",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8905,7 +8971,7 @@
   "name" : "nwbibsubject",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "141",
+  "weight" : "142",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8927,7 +8993,7 @@
   "name" : "series",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "170",
+  "weight" : "172",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8938,7 +9004,7 @@
   "name" : "subjectAltLabel",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "209",
+  "weight" : "217",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8949,7 +9015,7 @@
   "name" : "subjectChain",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "101",
+  "weight" : "102",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8960,7 +9026,7 @@
   "name" : "subjectLabel",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "208",
+  "weight" : "216",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8969,7 +9035,7 @@
   "name" : "subjectLocation",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "142",
+  "weight" : "143",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8980,7 +9046,7 @@
   "name" : "subjectOrder",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "143",
+  "weight" : "144",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8991,7 +9057,7 @@
   "name" : "titleKeyword",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "93",
+  "weight" : "94",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -9002,7 +9068,7 @@
   "name" : "urn",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "81",
+  "weight" : "82",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19764,20 +19830,22 @@
   "comment" : "",
   "label" : "Artikel",
   "icon" : "octicon octicon-file-text",
-  "name" : "article",
+  "name" : "Article",
+  "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
-  "type" : "STORE",
+  "weight" : "235",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/AudioDocument",
   "comment" : "",
   "label" : "Audio-Dokument",
   "icon" : "",
-  "name" : "audioDocument",
+  "name" : "AudioDocument",
+  "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
-  "type" : "STORE",
+  "weight" : "236",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/AudioVisualDocument",
@@ -19785,16 +19853,21 @@
   "label" : "Audio-Visuell",
   "icon" : "",
   "name" : "bibo:AudioVisual",
+  "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
-  "type" : "STORE",
+  "weight" : "256",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Book",
-  "label" : "Buch",
+  "comment" : "",
+  "label" : "Monografie",
   "icon" : "fa fa-book",
   "name" : "Book",
-  "type" : "STORE",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "237",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Chapter",
@@ -19802,65 +19875,87 @@
   "label" : "Kapitel",
   "icon" : "",
   "name" : "Chapter",
+  "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
-  "type" : "STORE",
+  "weight" : "238",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Collection",
+  "comment" : "",
   "label" : "Sammlung",
   "icon" : "glyphicon glyphicon-th-large",
   "name" : "Collection",
-  "type" : "STORE",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "239",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/DocumentPart",
   "comment" : "",
   "label" : "Unterordnung",
   "icon" : "fa fa-folder-o",
-  "name" : "documentPart",
+  "name" : "DocumentPart",
+  "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
-  "type" : "STORE",
+  "weight" : "240",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Image",
+  "comment" : "",
   "label" : "Bild",
   "icon" : "fa fa-file-image-o",
   "name" : "Image",
-  "type" : "STORE",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "241",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Issue",
   "comment" : "",
   "label" : "Ausgabe",
   "icon" : "fa fa-clone",
-  "name" : "issue",
+  "name" : "Issue",
+  "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
-  "type" : "STORE",
+  "weight" : "242",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Journal",
+  "comment" : "",
   "label" : "Journal",
   "icon" : "fa fa-newspaper-o",
   "name" : "Journal",
-  "type" : "STORE",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "243",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Manuscript",
+  "comment" : "",
   "label" : "Manuskript",
-  "type" : "STORE",
+  "icon" : "",
+  "name" : "Manuscript",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "244",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Map",
   "comment" : "",
   "label" : "Karte",
   "icon" : "",
-  "name" : "map",
+  "name" : "Map",
+  "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
-  "type" : "STORE",
+  "weight" : "245",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/MultiVolumeBook",
@@ -19868,33 +19963,43 @@
   "label" : "Mehrbändiges Werk",
   "icon" : "",
   "name" : "MultiVolumeBook",
+  "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
-  "type" : "STORE",
+  "weight" : "246",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Newspaper",
+  "comment" : "",
   "label" : "Zeitung",
   "icon" : "octicon octicon-book",
   "name" : "Newspaper",
-  "type" : "STORE",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "247",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Periodical",
+  "comment" : "",
   "label" : "Periodikum",
   "icon" : "fa fa-newspaper-o",
   "name" : "Periodical",
-  "type" : "STORE",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "250",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Proceedings",
-  "comment" : "Markdown provides backslash escapes for the following characters:\r\n\r\n    \\   backslash\r\n    `   backtick\r\n    *   asterisk\r\n    _   underscore\r\n    {}  curly braces\r\n    []  square brackets\r\n    ()  parentheses\r\n    #   hash mark\r\n\t+\tplus sign\r\n\t-\tminus sign (hyphen)\r\n    .   dot\r\n    !   exclamation mark\r\n\r\n",
-  "label" : "Konferenzschrift",
+  "comment" : "",
+  "label" : "Kongressschrift",
   "icon" : "octicon octicon-three-bars",
-  "name" : "proceeding",
+  "name" : "Proceeding",
+  "referenceType" : "@id",
   "container" : "",
-  "weight" : "2",
-  "type" : "STORE",
+  "weight" : "249",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/ReferenceSource",
@@ -19904,7 +20009,7 @@
   "name" : "ReferenceSource",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "189",
+  "weight" : "197",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19915,15 +20020,19 @@
   "name" : "Report",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "190",
+  "weight" : "198",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Series",
+  "comment" : "",
   "label" : "Reihe",
   "icon" : "glyphicon glyphicon-th-large",
-  "name" : "series",
-  "type" : "STORE",
+  "name" : "Series",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "251",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Standard",
@@ -19931,16 +20040,21 @@
   "label" : "Leitlinien / Normschriften",
   "icon" : "fa fa-university ",
   "name" : "Standard",
+  "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
-  "type" : "STORE",
+  "weight" : "252",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Thesis",
+  "comment" : "",
   "label" : "Abschlussarbeit",
   "icon" : "octicon octicon-mortar-board",
   "name" : "Thesis",
-  "type" : "STORE",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "253",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/Volume",
@@ -19948,9 +20062,10 @@
   "label" : "Jahrgang",
   "icon" : "fa fa-calendar-o",
   "name" : "volume",
+  "referenceType" : "@id",
   "container" : "",
-  "weight" : "",
-  "type" : "STORE",
+  "weight" : "255",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/doi",
@@ -19960,7 +20075,7 @@
   "name" : "bibo:doi",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "78",
+  "weight" : "79",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19977,12 +20092,12 @@
 }, {
   "uri" : "http://purl.org/ontology/bibo/editor",
   "comment" : "",
-  "label" : "Herausgeber/in",
+  "label" : "(Academic) Editor",
   "icon" : "",
   "name" : "editor",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "144",
+  "weight" : "145",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20004,7 +20119,7 @@
   "name" : "Isbn",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "145",
+  "weight" : "146",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20015,7 +20130,7 @@
   "name" : "isbn",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "146",
+  "weight" : "147",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20026,12 +20141,12 @@
   "name" : "isbn13",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "147",
+  "weight" : "148",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/issn",
-  "comment" : "**HELLO**",
+  "comment" : "",
   "label" : "ISSN",
   "icon" : "",
   "name" : "issn",
@@ -20045,18 +20160,19 @@
   "label" : "Lccn",
   "name" : "lccn",
   "referenceType" : "String",
-  "weight" : "148",
+  "weight" : "149",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/oclcnum",
   "comment" : "",
-  "label" : "",
+  "label" : "OCLC Nummer",
   "icon" : "",
   "name" : "oclcNumber",
+  "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "",
-  "type" : "STORE",
+  "weight" : "254",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/ontology/bibo/shortTitle",
@@ -20088,7 +20204,7 @@
   "name" : "callNumber",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "149",
+  "weight" : "150",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20099,7 +20215,7 @@
   "name" : "collectedBy",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "150",
+  "weight" : "151",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20125,7 +20241,7 @@
   "name" : "ismn",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "151",
+  "weight" : "152",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20136,7 +20252,7 @@
   "name" : "wikipedia",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "152",
+  "weight" : "153",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20147,7 +20263,7 @@
   "name" : "Item",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "191",
+  "weight" : "199",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20162,7 +20278,7 @@
   "label" : "Exemplar",
   "name" : "exemplar",
   "referenceType" : "String",
-  "weight" : "153",
+  "weight" : "154",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20171,7 +20287,7 @@
   "name" : "exemplarOf",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "154",
+  "weight" : "155",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20180,7 +20296,7 @@
   "name" : "owner",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "155",
+  "weight" : "156",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20189,7 +20305,7 @@
   "name" : "isSupplementTo",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "156",
+  "weight" : "157",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20200,7 +20316,7 @@
   "name" : "predecessor",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "195",
+  "weight" : "203",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20211,7 +20327,7 @@
   "name" : "successor",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "196",
+  "weight" : "204",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20220,7 +20336,7 @@
   "name" : "hasSupplement",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "157",
+  "weight" : "158",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20231,7 +20347,7 @@
   "name" : "corporateBodyForTitle",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "197",
+  "weight" : "205",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20242,7 +20358,7 @@
   "name" : "P60489",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "158",
+  "weight" : "159",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20275,7 +20391,7 @@
   "name" : "natureOfContent",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "210",
+  "weight" : "218",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20309,7 +20425,7 @@
   "name" : "frequency",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "160",
+  "weight" : "161",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20318,7 +20434,7 @@
   "name" : "longitudeAndLatitude",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "161",
+  "weight" : "162",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20373,7 +20489,7 @@
   "name" : "workManifested",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "162",
+  "weight" : "163",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20425,7 +20541,7 @@
   "name" : "endDate",
   "referenceType" : "http://www.w3.org/2001/XMLSchema#gYear",
   "container" : "@set",
-  "weight" : "198",
+  "weight" : "206",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20436,7 +20552,7 @@
   "name" : "location",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "199",
+  "weight" : "207",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20458,7 +20574,7 @@
   "name" : "publishedBy",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "206",
+  "weight" : "214",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20469,7 +20585,7 @@
   "name" : "startDate",
   "referenceType" : "http://www.w3.org/2001/XMLSchema#gYear",
   "container" : "@set",
-  "weight" : "200",
+  "weight" : "208",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20600,7 +20716,7 @@
   "name" : "isLike",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "212",
+  "weight" : "220",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20626,7 +20742,7 @@
   "name" : "componentList",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "201",
+  "weight" : "209",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20637,7 +20753,7 @@
   "name" : "itemID",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "216",
+  "weight" : "224",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20645,7 +20761,7 @@
   "label" : "beschreibt",
   "name" : "describes",
   "referenceType" : "@id",
-  "weight" : "163",
+  "weight" : "164",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20656,7 +20772,7 @@
   "name" : "isAggregatedBy",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "164",
+  "weight" : "165",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20664,7 +20780,7 @@
   "label" : "Beschrieben durch",
   "name" : "isDescribedBy",
   "referenceType" : "@id",
-  "weight" : "213",
+  "weight" : "221",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20675,7 +20791,7 @@
   "name" : "similarTo",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "223",
+  "weight" : "231",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20686,7 +20802,7 @@
   "name" : "isLike",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "214",
+  "weight" : "222",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20696,7 +20812,7 @@
   "icon" : "",
   "name" : "rdftype",
   "referenceType" : "@id",
-  "container" : "",
+  "container" : "@set",
   "weight" : "59",
   "type" : "CONTEXT",
   "multilangLabel" : { }
@@ -20705,7 +20821,7 @@
   "label" : "",
   "name" : "inDataset",
   "referenceType" : "String",
-  "weight" : "165",
+  "weight" : "166",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20727,7 +20843,7 @@
   "name" : "seeAlso",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "166",
+  "weight" : "167",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20738,7 +20854,7 @@
   "name" : "xsd",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "167",
+  "weight" : "168",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20749,7 +20865,7 @@
   "name" : "sameAs",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "217",
+  "weight" : "225",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20760,7 +20876,7 @@
   "name" : "altLabel",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "202",
+  "weight" : "210",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20769,7 +20885,7 @@
   "name" : "note",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "168",
+  "weight" : "169",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20780,7 +20896,7 @@
   "name" : "prefLabel",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "169",
+  "weight" : "171",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20799,7 +20915,7 @@
   "label" : "Beschrieben durch",
   "name" : "describedby",
   "referenceType" : "@id",
-  "weight" : "220",
+  "weight" : "228",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20807,7 +20923,7 @@
   "label" : "Gegenstand von",
   "name" : "isPrimaryTopicOf",
   "referenceType" : "@id",
-  "weight" : "221",
+  "weight" : "229",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20818,7 +20934,7 @@
   "name" : "primaryTopic",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "215",
+  "weight" : "223",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -21224,6 +21340,17 @@
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
+  "uri" : "info:regal/regal/joinedFunding",
+  "comment" : "",
+  "label" : "Förderung",
+  "icon" : "",
+  "name" : "joinedFunding",
+  "referenceType" : "@id",
+  "container" : "@list",
+  "weight" : "183",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
   "uri" : "info:regal/regal/publishLocation",
   "comment" : "",
   "label" : "Erscheinungsort",
@@ -21278,9 +21405,30 @@
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
+  "uri" : "info:regal/zettel/additionalNotes",
+  "comment" : "",
+  "label" : "Hinweis",
+  "icon" : "",
+  "name" : "additionalNotes",
+  "referenceType" : "String",
+  "container" : "",
+  "weight" : "170",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
+  "uri" : "info:regal/zettel/additionalNotesHeader",
+  "comment" : "",
+  "label" : "Erweiterte Angaben",
+  "icon" : "",
+  "name" : "",
+  "container" : "",
+  "weight" : "",
+  "type" : "STORE",
+  "multilangLabel" : { }
+}, {
   "uri" : "info:regal/zettel/catalogingHeader",
   "comment" : "",
-  "label" : "Inhaltliche Angaben",
+  "label" : "Angaben zum Inhalt",
   "icon" : "",
   "name" : "",
   "container" : "",
@@ -21324,7 +21472,7 @@
 }, {
   "uri" : "info:regal/zettel/creatorshipHeader",
   "comment" : "",
-  "label" : "Urheberschaft",
+  "label" : "Angaben zur Urheberschaft",
   "icon" : "",
   "name" : "",
   "container" : "",
@@ -21339,7 +21487,7 @@
   "name" : "fulltextVersion",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "79",
+  "weight" : "80",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -21355,12 +21503,23 @@
 }, {
   "uri" : "info:regal/zettel/identifiersHeader",
   "comment" : "",
-  "label" : "Externe Referenzen",
+  "label" : "Externe und interne Referenzen",
   "icon" : "",
   "name" : "",
   "container" : "",
   "weight" : "",
   "type" : "STORE",
+  "multilangLabel" : { }
+}, {
+  "uri" : "info:regal/zettel/internalReference",
+  "comment" : "",
+  "label" : "Interne Referenz",
+  "icon" : "",
+  "name" : "internalReference",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "70",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "info:regal/zettel/leibniz/org/BIPS",
@@ -21705,7 +21864,7 @@
 }, {
   "uri" : "info:regal/zettel/titleHeader",
   "comment" : "",
-  "label" : "Titelangaben",
+  "label" : "Angaben zum Titel",
   "icon" : "",
   "name" : "",
   "container" : "",
@@ -21720,8 +21879,12 @@
   "multilangLabel" : { }
 }, {
   "uri" : "info:regal/zettel/uploadHeader",
-  "label" : "Dateiupload",
-  "referenceType" : "String",
+  "comment" : "",
+  "label" : "Angaben zur Datei",
+  "icon" : "",
+  "name" : "",
+  "container" : "",
+  "weight" : "",
   "type" : "STORE",
   "multilangLabel" : { }
 }, {

--- a/conf/labels.json
+++ b/conf/labels.json
@@ -6,7 +6,7 @@
   "name" : "agent",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "9",
+  "weight" : "12",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -17,7 +17,7 @@
   "name" : "contribution",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "11",
+  "weight" : "14",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -28,7 +28,7 @@
   "name" : "role",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "76",
+  "weight" : "85",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -69,7 +69,7 @@
   "name" : "ConferenceOrEvent",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "182",
+  "weight" : "176",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -80,7 +80,7 @@
   "name" : "CorporateBody",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "183",
+  "weight" : "177",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -91,7 +91,7 @@
   "name" : "DifferentiatedPerson",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "184",
+  "weight" : "178",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -102,7 +102,7 @@
   "name" : "Family",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "185",
+  "weight" : "179",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -113,7 +113,7 @@
   "name" : "Person",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "186",
+  "weight" : "180",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -124,7 +124,7 @@
   "name" : "PlaceOrGeographicName",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "187",
+  "weight" : "181",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -135,7 +135,7 @@
   "name" : "SubjectHeading",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "188",
+  "weight" : "182",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -146,7 +146,7 @@
   "name" : "Work",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "189",
+  "weight" : "183",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -157,7 +157,7 @@
   "name" : "dateOfBirth",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "85",
+  "weight" : "94",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -168,7 +168,7 @@
   "name" : "dateOfDeath",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "86",
+  "weight" : "95",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -179,7 +179,7 @@
   "name" : "preferredName",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "87",
+  "weight" : "96",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -187,7 +187,7 @@
   "label" : "",
   "name" : "preferredNameEntityForThePerson",
   "referenceType" : "String",
-  "weight" : "88",
+  "weight" : "97",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -195,7 +195,7 @@
   "label" : "",
   "name" : "preferredNameForTheConferenceOrEvent",
   "referenceType" : "String",
-  "weight" : "89",
+  "weight" : "98",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -206,7 +206,7 @@
   "name" : "preferredNameForTheCorporateBody",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "90",
+  "weight" : "99",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -214,7 +214,7 @@
   "label" : "",
   "name" : "preferredNameForTheFamily",
   "referenceType" : "String",
-  "weight" : "91",
+  "weight" : "100",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -225,7 +225,7 @@
   "name" : "preferredNameForThePerson",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "93",
+  "weight" : "102",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -233,7 +233,7 @@
   "label" : "",
   "name" : "preferredNameForThePlaceOrGeographicName",
   "referenceType" : "String",
-  "weight" : "94",
+  "weight" : "103",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -241,7 +241,7 @@
   "label" : "",
   "name" : "preferredNameForTheSubjectHeading",
   "referenceType" : "String",
-  "weight" : "95",
+  "weight" : "104",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -249,7 +249,7 @@
   "label" : "",
   "name" : "preferredNameForTheWork",
   "referenceType" : "String",
-  "weight" : "96",
+  "weight" : "105",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -260,7 +260,7 @@
   "name" : "gnd:publication",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "48",
+  "weight" : "47",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -273,12 +273,12 @@
 }, {
   "uri" : "http://dbpedia.org/ontology/institution",
   "comment" : "",
-  "label" : "Sammlungszuordnung",
+  "label" : "Sammlung",
   "icon" : "",
   "name" : "institution",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "215",
+  "weight" : "63",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -393,7 +393,7 @@
   "multilangLabel" : { }
 }, {
   "uri" : "http://dewey.info/class/018/",
-  "label" : "Kataloge nach Autor, Erscheinungsjahr usw.",
+  "label" : "Kataloge nach Autor/in, Erscheinungsjahr usw.",
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
@@ -5859,7 +5859,7 @@
   "name" : "checksum",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "97",
+  "weight" : "106",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -5867,7 +5867,7 @@
   "label" : "",
   "name" : "generator",
   "referenceType" : "@id",
-  "weight" : "98",
+  "weight" : "107",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -5875,7 +5875,7 @@
   "label" : "Größe",
   "name" : "size",
   "referenceType" : "String",
-  "weight" : "99",
+  "weight" : "108",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -5891,7 +5891,7 @@
   "name" : "hasURN",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "69",
+  "weight" : "80",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6122,7 +6122,7 @@
   "name" : "accessScheme",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "179",
+  "weight" : "219",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6133,7 +6133,7 @@
   "name" : "affiliationIndex",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "6",
+  "weight" : "9",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6144,7 +6144,7 @@
   "name" : "agrovoc",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "100",
+  "weight" : "109",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6198,7 +6198,7 @@
   "name" : "catalogLink",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "71",
+  "weight" : "82",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6275,7 +6275,7 @@
   "name" : "contentType",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "180",
+  "weight" : "211",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6283,7 +6283,7 @@
   "label" : "Erstellt von",
   "name" : "createdBy",
   "referenceType" : "String",
-  "weight" : "101",
+  "weight" : "110",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6294,7 +6294,7 @@
   "name" : "dataOrigin",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "102",
+  "weight" : "111",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6305,7 +6305,7 @@
   "name" : "ddc",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "104",
+  "weight" : "112",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6316,7 +6316,7 @@
   "name" : "doi",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "105",
+  "weight" : "113",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6327,7 +6327,7 @@
   "name" : "embargoTime",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "61",
+  "weight" : "66",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6338,7 +6338,7 @@
   "name" : "funding",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "175",
+  "weight" : "172",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6349,7 +6349,7 @@
   "name" : "fundingProgram",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "177",
+  "weight" : "174",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6360,7 +6360,7 @@
   "name" : "hasData",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "106",
+  "weight" : "114",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6371,7 +6371,7 @@
   "name" : "hasTransformer",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "107",
+  "weight" : "115",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6379,7 +6379,7 @@
   "label" : "Import",
   "name" : "importedFrom",
   "referenceType" : "String",
-  "weight" : "108",
+  "weight" : "116",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6390,7 +6390,7 @@
   "name" : "externalParent",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "74",
+  "weight" : "83",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6419,7 +6419,7 @@
   "label" : "Bearbeitet von",
   "name" : "lastModifiedBy",
   "referenceType" : "String",
-  "weight" : "109",
+  "weight" : "117",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6427,7 +6427,7 @@
   "label" : "Id Altsystem",
   "name" : "legacyId",
   "referenceType" : "String",
-  "weight" : "110",
+  "weight" : "118",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6438,7 +6438,7 @@
   "name" : "license",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "60",
+  "weight" : "67",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6446,7 +6446,7 @@
   "label" : "Interner Name",
   "name" : "name",
   "referenceType" : "String",
-  "weight" : "111",
+  "weight" : "119",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6457,7 +6457,7 @@
   "name" : "nextVersion",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "78",
+  "weight" : "87",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6468,7 +6468,7 @@
   "name" : "objectTimestamp",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "112",
+  "weight" : "120",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6500,7 +6500,7 @@
   "name" : "parallelEdition",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "72",
+  "weight" : "226",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6541,7 +6541,7 @@
   "name" : "previousVersion",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "79",
+  "weight" : "88",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6552,7 +6552,7 @@
   "name" : "professionalGroup",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "103",
+  "weight" : "76",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6563,7 +6563,7 @@
   "name" : "projectId",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "176",
+  "weight" : "173",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6574,7 +6574,7 @@
   "name" : "publicationStatus",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "16",
+  "weight" : "70",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6585,7 +6585,7 @@
   "name" : "publicationYear",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "18",
+  "weight" : "60",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6596,7 +6596,7 @@
   "name" : "publishScheme",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "178",
+  "weight" : "218",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6607,7 +6607,7 @@
   "name" : "recordingCoordinates",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "80",
+  "weight" : "89",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6618,7 +6618,7 @@
   "name" : "recordingLocation",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "81",
+  "weight" : "90",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6629,7 +6629,7 @@
   "name" : "recordingPeriod",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "82",
+  "weight" : "91",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6651,7 +6651,7 @@
   "name" : "relatedResource",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "83",
+  "weight" : "92",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6662,7 +6662,7 @@
   "name" : "reviewStatus",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "17",
+  "weight" : "71",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6683,7 +6683,7 @@
   "name" : "titleLanguage",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "8",
+  "weight" : "11",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6694,7 +6694,7 @@
   "name" : "usageManual",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "14",
+  "weight" : "17",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6716,7 +6716,7 @@
   "name" : "volumeIn",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "51",
+  "weight" : "54",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6727,7 +6727,7 @@
   "name" : "yearOfCopyright",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "59",
+  "weight" : "65",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6743,7 +6743,7 @@
   "name" : "agent",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "10",
+  "weight" : "13",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6754,7 +6754,7 @@
   "name" : "contribution",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "12",
+  "weight" : "15",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6765,7 +6765,7 @@
   "name" : "extent",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "214",
+  "weight" : "207",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6776,7 +6776,7 @@
   "name" : "frequency",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "153",
+  "weight" : "159",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6787,7 +6787,7 @@
   "name" : "hasItem",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "73",
+  "weight" : "225",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6798,7 +6798,7 @@
   "name" : "heldBy",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "210",
+  "weight" : "203",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6809,7 +6809,7 @@
   "name" : "itemOf",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "211",
+  "weight" : "204",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6818,9 +6818,9 @@
   "label" : "Verantwortlich",
   "icon" : "",
   "name" : "responsibilityStatement",
-  "referenceType" : "@id",
+  "referenceType" : "String",
   "container" : "@set",
-  "weight" : "7",
+  "weight" : "10",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6831,7 +6831,7 @@
   "name" : "role",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "77",
+  "weight" : "86",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6842,7 +6842,7 @@
   "name" : "source",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "125",
+  "weight" : "131",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -6853,7 +6853,7 @@
   "name" : "supplement",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "212",
+  "weight" : "205",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -7768,7 +7768,7 @@
   "multilangLabel" : { }
 }, {
   "uri" : "http://id.loc.gov/vocabulary/relators/aft",
-  "label" : "Autor des Nachwortes",
+  "label" : "Autor/in des Nachwortes",
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
@@ -7823,7 +7823,7 @@
   "multilangLabel" : { }
 }, {
   "uri" : "http://id.loc.gov/vocabulary/relators/ctb",
-  "label" : "Mitwirkende",
+  "label" : "Mitwirkende/r",
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
@@ -7918,7 +7918,12 @@
   "multilangLabel" : { }
 }, {
   "uri" : "http://id.loc.gov/vocabulary/relators/red",
+  "comment" : "",
   "label" : "Redaktion",
+  "icon" : "",
+  "name" : "loc:red",
+  "container" : "",
+  "weight" : "",
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
@@ -7941,7 +7946,7 @@
   "label" : "Gesamttitel",
   "name" : "P1004",
   "referenceType" : "String",
-  "weight" : "113",
+  "weight" : "121",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -7952,7 +7957,7 @@
   "name" : "P1006",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "114",
+  "weight" : "122",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -7963,7 +7968,7 @@
   "name" : "P1016",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "115",
+  "weight" : "123",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -7982,7 +7987,7 @@
   "label" : "Kombination",
   "name" : "T1008",
   "referenceType" : "String",
-  "weight" : "116",
+  "weight" : "124",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8192,7 +8197,7 @@
   "name" : "fulltextOnline",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "117",
+  "weight" : "224",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8328,12 +8333,12 @@
 }, {
   "uri" : "http://purl.org/dc/elements/1.1/contributor",
   "comment" : "",
-  "label" : "Mitwirkende",
+  "label" : "Mitwirkende/r",
   "icon" : "",
   "name" : "contributorName",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "15",
+  "weight" : "18",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8344,13 +8349,13 @@
   "name" : "coverage",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "118",
+  "weight" : "125",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/dc/elements/1.1/creator",
   "comment" : "",
-  "label" : "Autor",
+  "label" : "Autor/in",
   "icon" : "",
   "name" : "creatorName",
   "referenceType" : "String",
@@ -8366,7 +8371,7 @@
   "name" : "isPartOfName",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "174",
+  "weight" : "171",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8377,7 +8382,7 @@
   "name" : "publisher",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "66",
+  "weight" : "77",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8388,7 +8393,7 @@
   "name" : "subjectName",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "217",
+  "weight" : "75",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8401,12 +8406,12 @@
 }, {
   "uri" : "http://purl.org/dc/terms/abstract",
   "comment" : "",
-  "label" : "Zusammenfassung",
+  "label" : "Abstract/Summary",
   "icon" : "",
   "name" : "abstractText",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "65",
+  "weight" : "73",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8417,7 +8422,7 @@
   "name" : "alternative",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "2",
+  "weight" : "3",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8428,13 +8433,13 @@
   "name" : "bibliographicCitation",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "46",
+  "weight" : "62",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/dc/terms/contributor",
   "comment" : "",
-  "label" : "Mitwirkende",
+  "label" : "Mitwirkende/r",
   "icon" : "",
   "name" : "contributor",
   "referenceType" : "@id",
@@ -8450,13 +8455,13 @@
   "name" : "created",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "119",
+  "weight" : "126",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/dc/terms/creator",
   "comment" : "",
-  "label" : "Autor",
+  "label" : "Autor/in",
   "icon" : "",
   "name" : "creator",
   "referenceType" : "@id",
@@ -8470,7 +8475,7 @@
   "name" : "description",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "120",
+  "weight" : "127",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8478,7 +8483,7 @@
   "label" : "Format",
   "name" : "format",
   "referenceType" : "String",
-  "weight" : "121",
+  "weight" : "128",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8487,7 +8492,7 @@
   "name" : "hasFormat",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "122",
+  "weight" : "129",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8498,7 +8503,7 @@
   "name" : "hasPart",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "181",
+  "weight" : "175",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8509,7 +8514,7 @@
   "name" : "hasVersion",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "123",
+  "weight" : "222",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8520,7 +8525,7 @@
   "name" : "primaryForm",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "199",
+  "weight" : "192",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8531,18 +8536,18 @@
   "name" : "parentPid",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "75",
+  "weight" : "84",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/dc/terms/issued",
   "comment" : "",
-  "label" : "Erschienen in",
+  "label" : "Erscheinungsjahr",
   "icon" : "",
   "name" : "issued",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "49",
+  "weight" : "50",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8553,7 +8558,7 @@
   "name" : "language",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "64",
+  "weight" : "72",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8564,7 +8569,7 @@
   "name" : "medium",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "57",
+  "weight" : "58",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8575,7 +8580,7 @@
   "name" : "modified",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "124",
+  "weight" : "130",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8586,7 +8591,7 @@
   "name" : "source",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "126",
+  "weight" : "132",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8597,7 +8602,7 @@
   "name" : "spatial",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "127",
+  "weight" : "133",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8608,7 +8613,7 @@
   "name" : "subject",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "216",
+  "weight" : "74",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8619,7 +8624,7 @@
   "name" : "tableOfContents",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "128",
+  "weight" : "134",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8630,7 +8635,7 @@
   "name" : "title",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "1",
+  "weight" : "2",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8655,7 +8660,7 @@
   "name" : "Game",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "190",
+  "weight" : "184",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8718,7 +8723,7 @@
   "name" : "MultiVolumeWorkRelation",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "191",
+  "weight" : "185",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8729,7 +8734,7 @@
   "name" : "OfficialPublication",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "192",
+  "weight" : "186",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8740,7 +8745,7 @@
   "name" : "Schoolbook",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "193",
+  "weight" : "187",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8751,7 +8756,7 @@
   "name" : "SeriesRelation",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "194",
+  "weight" : "188",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8772,7 +8777,7 @@
   "name" : "containedIn",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "54",
+  "weight" : "61",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8783,7 +8788,7 @@
   "name" : "contributorOrder",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "129",
+  "weight" : "135",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8794,7 +8799,7 @@
   "name" : "fulltextOnline",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "130",
+  "weight" : "136",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8805,7 +8810,7 @@
   "name" : "hasSuperordinate",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "200",
+  "weight" : "193",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8827,7 +8832,7 @@
   "name" : "inCollection",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "201",
+  "weight" : "194",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8838,7 +8843,7 @@
   "name" : "inSeries",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "52",
+  "weight" : "53",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8849,7 +8854,7 @@
   "name" : "lv:isPartOf",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "56",
+  "weight" : "57",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8858,7 +8863,7 @@
   "name" : "multiVolumeWork",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "131",
+  "weight" : "137",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8867,7 +8872,7 @@
   "name" : "contributingCorporateBodyLabel",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "132",
+  "weight" : "138",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8878,7 +8883,7 @@
   "name" : "numbering",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "133",
+  "weight" : "139",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8889,7 +8894,7 @@
   "name" : "nwbibspatial",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "134",
+  "weight" : "140",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8900,7 +8905,7 @@
   "name" : "nwbibsubject",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "135",
+  "weight" : "141",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8922,18 +8927,18 @@
   "name" : "series",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "173",
+  "weight" : "170",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/lobid/lv#subjectAltLabel",
   "comment" : "",
-  "label" : "Freie Schlagwörter",
+  "label" : "Schlagwörter",
   "icon" : "",
   "name" : "subjectAltLabel",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "219",
+  "weight" : "209",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8944,7 +8949,7 @@
   "name" : "subjectChain",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "92",
+  "weight" : "101",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8955,7 +8960,7 @@
   "name" : "subjectLabel",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "218",
+  "weight" : "208",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8964,7 +8969,7 @@
   "name" : "subjectLocation",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "136",
+  "weight" : "142",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8975,7 +8980,7 @@
   "name" : "subjectOrder",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "137",
+  "weight" : "143",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8986,7 +8991,7 @@
   "name" : "titleKeyword",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "84",
+  "weight" : "93",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -8997,7 +9002,7 @@
   "name" : "urn",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "70",
+  "weight" : "81",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -9008,7 +9013,7 @@
   "name" : "lv:volumeIn",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "53",
+  "weight" : "55",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -9017,7 +9022,7 @@
   "name" : "webPageArchived",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "4",
+  "weight" : "7",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -13074,12 +13079,12 @@
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/lobid/nwbib#s768010",
-  "label" : "Einzelne Autoren (Primärliteratur)",
+  "label" : "Einzelne AutorInnen (Primärliteratur)",
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
   "uri" : "http://purl.org/lobid/nwbib#s768030",
-  "label" : "Einzelne Autoren (Sekundärliteratur)",
+  "label" : "Einzelne AutorInnen (Sekundärliteratur)",
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
@@ -19792,6 +19797,16 @@
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
+  "uri" : "http://purl.org/ontology/bibo/Chapter",
+  "comment" : "",
+  "label" : "Kapitel",
+  "icon" : "",
+  "name" : "Chapter",
+  "container" : "",
+  "weight" : "",
+  "type" : "STORE",
+  "multilangLabel" : { }
+}, {
   "uri" : "http://purl.org/ontology/bibo/Collection",
   "label" : "Sammlung",
   "icon" : "glyphicon glyphicon-th-large",
@@ -19889,7 +19904,7 @@
   "name" : "ReferenceSource",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "195",
+  "weight" : "189",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19900,7 +19915,7 @@
   "name" : "Report",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "196",
+  "weight" : "190",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19945,7 +19960,7 @@
   "name" : "bibo:doi",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "67",
+  "weight" : "78",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19962,12 +19977,12 @@
 }, {
   "uri" : "http://purl.org/ontology/bibo/editor",
   "comment" : "",
-  "label" : "Herausgeber",
+  "label" : "Herausgeber/in",
   "icon" : "",
   "name" : "editor",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "138",
+  "weight" : "144",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -19989,7 +20004,7 @@
   "name" : "Isbn",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "139",
+  "weight" : "145",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20000,7 +20015,7 @@
   "name" : "isbn",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "140",
+  "weight" : "146",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20011,7 +20026,7 @@
   "name" : "isbn13",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "141",
+  "weight" : "147",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20030,7 +20045,7 @@
   "label" : "Lccn",
   "name" : "lccn",
   "referenceType" : "String",
-  "weight" : "142",
+  "weight" : "148",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20073,7 +20088,7 @@
   "name" : "callNumber",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "143",
+  "weight" : "149",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20084,7 +20099,7 @@
   "name" : "collectedBy",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "144",
+  "weight" : "150",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20110,7 +20125,7 @@
   "name" : "ismn",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "145",
+  "weight" : "151",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20121,7 +20136,7 @@
   "name" : "wikipedia",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "146",
+  "weight" : "152",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20132,7 +20147,7 @@
   "name" : "Item",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "198",
+  "weight" : "191",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20147,7 +20162,7 @@
   "label" : "Exemplar",
   "name" : "exemplar",
   "referenceType" : "String",
-  "weight" : "147",
+  "weight" : "153",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20156,7 +20171,7 @@
   "name" : "exemplarOf",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "148",
+  "weight" : "154",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20165,7 +20180,7 @@
   "name" : "owner",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "149",
+  "weight" : "155",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20174,7 +20189,7 @@
   "name" : "isSupplementTo",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "150",
+  "weight" : "156",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20185,7 +20200,7 @@
   "name" : "predecessor",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "202",
+  "weight" : "195",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20196,7 +20211,7 @@
   "name" : "successor",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "203",
+  "weight" : "196",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20205,7 +20220,7 @@
   "name" : "hasSupplement",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "151",
+  "weight" : "157",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20216,7 +20231,7 @@
   "name" : "corporateBodyForTitle",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "204",
+  "weight" : "197",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20227,18 +20242,41 @@
   "name" : "P60489",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "152",
+  "weight" : "158",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
+  "uri" : "http://rdaregistry.info/Elements/u/P60493",
+  "comment" : "",
+  "label" : "Titelzusatz weitere",
+  "icon" : "",
+  "name" : "otherTitleInformation",
+  "referenceType" : "String",
+  "container" : "@set",
+  "weight" : "4",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
+  "uri" : "http://rdaregistry.info/Elements/u/P60517",
+  "comment" : "",
+  "label" : "Unterreihe",
+  "icon" : "",
+  "name" : "titleOfSubSeries",
+  "referenceType" : "String",
+  "container" : "",
+  "weight" : "6",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://rdaregistry.info/Elements/u/P60584",
   "comment" : "",
-  "label" : "",
+  "label" : "Formschlagwörter",
   "icon" : "",
   "name" : "natureOfContent",
+  "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "",
-  "type" : "STORE",
+  "weight" : "210",
+  "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
   "uri" : "http://rdaregistry.info/termList/RDACarrierType/1018 ",
@@ -20271,7 +20309,7 @@
   "name" : "frequency",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "154",
+  "weight" : "160",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20280,7 +20318,7 @@
   "name" : "longitudeAndLatitude",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "155",
+  "weight" : "161",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20291,7 +20329,7 @@
   "name" : "otherTitleInformation",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "3",
+  "weight" : "5",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20324,7 +20362,7 @@
   "name" : "statementOfResponsibility",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "50",
+  "weight" : "52",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20335,7 +20373,7 @@
   "name" : "workManifested",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "156",
+  "weight" : "162",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20387,7 +20425,7 @@
   "name" : "endDate",
   "referenceType" : "http://www.w3.org/2001/XMLSchema#gYear",
   "container" : "@set",
-  "weight" : "205",
+  "weight" : "198",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20398,7 +20436,7 @@
   "name" : "location",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "206",
+  "weight" : "199",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20409,7 +20447,7 @@
   "name" : "publication",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "47",
+  "weight" : "46",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20420,7 +20458,7 @@
   "name" : "publishedBy",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "213",
+  "weight" : "206",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20431,7 +20469,7 @@
   "name" : "startDate",
   "referenceType" : "http://www.w3.org/2001/XMLSchema#gYear",
   "container" : "@set",
-  "weight" : "207",
+  "weight" : "200",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20562,7 +20600,7 @@
   "name" : "isLike",
   "referenceType" : "@id",
   "container" : "@set",
-  "weight" : "157",
+  "weight" : "212",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20588,7 +20626,7 @@
   "name" : "componentList",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "208",
+  "weight" : "201",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20599,7 +20637,7 @@
   "name" : "itemID",
   "referenceType" : "String",
   "container" : "",
-  "weight" : "158",
+  "weight" : "216",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20607,7 +20645,7 @@
   "label" : "beschreibt",
   "name" : "describes",
   "referenceType" : "@id",
-  "weight" : "159",
+  "weight" : "163",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20618,7 +20656,7 @@
   "name" : "isAggregatedBy",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "160",
+  "weight" : "164",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20626,7 +20664,7 @@
   "label" : "Beschrieben durch",
   "name" : "isDescribedBy",
   "referenceType" : "@id",
-  "weight" : "161",
+  "weight" : "213",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20637,7 +20675,7 @@
   "name" : "similarTo",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "162",
+  "weight" : "223",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20648,7 +20686,7 @@
   "name" : "isLike",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "163",
+  "weight" : "214",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20659,7 +20697,7 @@
   "name" : "rdftype",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "58",
+  "weight" : "59",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20667,7 +20705,7 @@
   "label" : "",
   "name" : "inDataset",
   "referenceType" : "String",
-  "weight" : "164",
+  "weight" : "165",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20678,7 +20716,7 @@
   "name" : "label",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "5",
+  "weight" : "8",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20689,7 +20727,7 @@
   "name" : "seeAlso",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "165",
+  "weight" : "166",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20700,7 +20738,7 @@
   "name" : "xsd",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "166",
+  "weight" : "167",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20711,7 +20749,7 @@
   "name" : "sameAs",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "167",
+  "weight" : "217",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20722,7 +20760,7 @@
   "name" : "altLabel",
   "referenceType" : "String",
   "container" : "@set",
-  "weight" : "209",
+  "weight" : "202",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20753,7 +20791,7 @@
   "name" : "affiliation",
   "referenceType" : "String",
   "container" : "@list",
-  "weight" : "13",
+  "weight" : "16",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20761,7 +20799,7 @@
   "label" : "Beschrieben durch",
   "name" : "describedby",
   "referenceType" : "@id",
-  "weight" : "170",
+  "weight" : "220",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20769,7 +20807,7 @@
   "label" : "Gegenstand von",
   "name" : "isPrimaryTopicOf",
   "referenceType" : "@id",
-  "weight" : "171",
+  "weight" : "221",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20780,7 +20818,7 @@
   "name" : "primaryTopic",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "172",
+  "weight" : "215",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -20797,6 +20835,16 @@
   "uri" : "https://creativecommons.org/licenses/by/4.0",
   "comment" : "",
   "label" : "CC BY 4.0",
+  "icon" : "",
+  "name" : "",
+  "container" : "",
+  "weight" : "",
+  "type" : "STORE",
+  "multilangLabel" : { }
+}, {
+  "uri" : "https://creativecommons.org/publicdomain/zero/1.0/",
+  "comment" : "",
+  "label" : "CC0 1.0",
   "icon" : "",
   "name" : "",
   "container" : "",
@@ -21176,6 +21224,49 @@
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
+  "uri" : "info:regal/regal/publishLocation",
+  "comment" : "",
+  "label" : "Erscheinungsort",
+  "icon" : "",
+  "name" : "regal:publishLocation",
+  "referenceType" : "String",
+  "container" : "",
+  "weight" : "48",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
+  "uri" : "info:regal/regal/publishYear",
+  "comment" : "",
+  "label" : "Erscheinungsjahr",
+  "icon" : "",
+  "name" : "regal:publishYear",
+  "referenceType" : "String",
+  "container" : "",
+  "weight" : "51",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
+  "uri" : "info:regal/regal/publishedBy",
+  "comment" : "",
+  "label" : "Verlag",
+  "icon" : "",
+  "name" : "regal:publishedBy",
+  "referenceType" : "String",
+  "container" : "",
+  "weight" : "49",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
+  "uri" : "info:regal/zettel/File",
+  "comment" : "",
+  "label" : "Datei",
+  "icon" : "",
+  "name" : "",
+  "container" : "",
+  "weight" : "",
+  "type" : "STORE",
+  "multilangLabel" : { }
+}, {
   "uri" : "info:regal/zettel/additionalMaterial",
   "comment" : "",
   "label" : "Ergänzendes Material",
@@ -21183,7 +21274,7 @@
   "name" : "additionalMaterial",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "63",
+  "weight" : "69",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -21205,12 +21296,23 @@
 }, {
   "uri" : "info:regal/zettel/collectionOne",
   "comment" : "",
-  "label" : "Leibniz Organisation",
+  "label" : "LeibnizOpen",
   "icon" : "",
   "name" : "collectionOne",
   "referenceType" : "@id",
   "container" : "",
-  "weight" : "55",
+  "weight" : "56",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
+  "uri" : "info:regal/zettel/collectionTwo",
+  "comment" : "",
+  "label" : "Übergeordneter Kongress ",
+  "icon" : "",
+  "name" : "collectionTwo",
+  "referenceType" : "@id",
+  "container" : "",
+  "weight" : "64",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -21237,7 +21339,7 @@
   "name" : "fulltextVersion",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "68",
+  "weight" : "79",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -21551,6 +21653,17 @@
   "type" : "STORE",
   "multilangLabel" : { }
 }, {
+  "uri" : "info:regal/zettel/notification",
+  "comment" : "",
+  "label" : "Wichtiger Hinweis",
+  "icon" : "fa fa-bell",
+  "name" : "notification",
+  "referenceType" : "String",
+  "container" : "",
+  "weight" : "1",
+  "type" : "CONTEXT",
+  "multilangLabel" : { }
+}, {
   "uri" : "info:regal/zettel/observationHeader",
   "label" : "Erfassung",
   "referenceType" : "String",
@@ -21570,7 +21683,7 @@
   "name" : "publisherVersion",
   "referenceType" : "@id",
   "container" : "@list",
-  "weight" : "62",
+  "weight" : "68",
   "type" : "CONTEXT",
   "multilangLabel" : { }
 }, {
@@ -21597,6 +21710,12 @@
   "name" : "",
   "container" : "",
   "weight" : "",
+  "type" : "STORE",
+  "multilangLabel" : { }
+}, {
+  "uri" : "info:regal/zettel/typeHeader",
+  "label" : "Publikationstyp",
+  "referenceType" : "String",
   "type" : "STORE",
   "multilangLabel" : { }
 }, {

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -236,7 +236,10 @@ do not display this fields
 .resourceTable .hasItem,
 .resourceTable .predecessor, 
 .resourceTable .successor, 
-.resourceTable .corporateBodyForTitle
+.resourceTable .corporateBodyForTitle,
+.resourceTable .funding,
+.resourceTable .projectId,
+.resourceTable .fundingProgram
 { 
 	display: none;
 }

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -239,7 +239,8 @@ do not display this fields
 .resourceTable .corporateBodyForTitle,
 .resourceTable .funding,
 .resourceTable .projectId,
-.resourceTable .fundingProgram
+.resourceTable .fundingProgram,
+.resourceTable .fundingId
 { 
 	display: none;
 }


### PR DESCRIPTION
Der Pullrequest enthält Änderungen aus dem Ticket FRL-448. Die Änderungen werden derzeit getestet (vom Kunden). 

Die wichtigsten Änderungen:
- Eine ressource kann nun mehrere Typen (rdftype) enthalten.
- An der LeibnizOpen-Schnittstelle können nun mehrere Typen gemeldet werden
- Die Anreicherungsroutine wurde aus Modify.java nach Enrich.java ausgelaggert und anschließend refactored. Die Anreicherungsroutine beruht nun komplett auf Etikett und reichert Labels zu allen URIs im Datensatz an.
- Für die Anzeige der Förderer-Felder wurde eine neue Darstellung generiert.

Die Installation der Codeänderungen erfordert eine Neuindexierung.
Dafür sollten zunächst alle bekannten IDs in einer Datei pid.txt gesammelt werden. Dann sollten die existierenden Indexe verschoben/gelöscht werden. Anschließend wird die Applikation mit den Änderungen neu gestartet und eine Neuindexierung wird angestoßen.
