### PR TITLE
Frl 469 und Frl 468

### DIFF
--- a/app/helper/JsonMapper.java
+++ b/app/helper/JsonMapper.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
@@ -407,9 +408,9 @@ public class JsonMapper {
 		}
 	}
 
-	private void postProcessSubjectName(Map<String, Object> rdf) {
+	private static void postProcessSubjectName(Map<String, Object> rdf) {
 		List<Map<String, Object>> newSubjects = new ArrayList<>();
-		List<String> subjects = (List<String>) rdf.get("subjectName");
+		Set<String> subjects = (Set<String>) rdf.get("subjectName");
 		if (subjects == null || subjects.isEmpty()) {
 			return;
 		}

--- a/app/helper/JsonMapper.java
+++ b/app/helper/JsonMapper.java
@@ -368,6 +368,7 @@ public class JsonMapper {
 				rdf.put(rdftype, t);
 
 			sortCreatorAndContributors(rdf);
+			postProcessSubjectName(rdf);
 			postProcess(rdf, "subject");
 			postProcess(rdf, "agrovoc");
 			postProcess(rdf, "contributor");
@@ -400,7 +401,6 @@ public class JsonMapper {
 			postProcessContribution(rdf);
 			postProcess(rdf, "creator");
 			createJoinedFunding(rdf);
-			postProcessSubjectName(rdf);
 
 		} catch (Exception e) {
 			play.Logger.debug("", e);

--- a/app/helper/JsonMapper.java
+++ b/app/helper/JsonMapper.java
@@ -400,10 +400,35 @@ public class JsonMapper {
 			postProcessContribution(rdf);
 			postProcess(rdf, "creator");
 			createJoinedFunding(rdf);
+			postProcessSubjectName(rdf);
 
 		} catch (Exception e) {
 			play.Logger.debug("", e);
 		}
+	}
+
+	private void postProcessSubjectName(Map<String, Object> rdf) {
+		List<Map<String, Object>> newSubjects = new ArrayList<>();
+		List<String> subjects = (List<String>) rdf.get("subjectName");
+		if (subjects == null || subjects.isEmpty()) {
+			return;
+		}
+		subjects.forEach((subject) -> {
+			String id = Globals.protocol + Globals.server + "/adhoc/uri/"
+					+ helper.MyURLEncoding.encode(subject);
+			Map<String, Object> subjectMap = new HashMap<>();
+			subjectMap.put("prefLabel", subject);
+			subjectMap.put("@id", id);
+			newSubjects.add(subjectMap);
+		});
+		rdf.remove("subjectName");
+		List<Map<String, Object>> oldSubjects =
+				(List<Map<String, Object>>) rdf.get("subject");
+		if (oldSubjects == null) {
+			oldSubjects = new ArrayList<>();
+		}
+		oldSubjects.addAll(newSubjects);
+		rdf.put("subject", oldSubjects);
 	}
 
 	private static void createJoinedFunding(Map<String, Object> rdf) {

--- a/app/views/Helper.java
+++ b/app/views/Helper.java
@@ -237,6 +237,9 @@ public class Helper {
 	public static String getSubjectSource(String sourceId, String uri,
 			String notation) {
 		String source = "";
+		if (uri == null) {
+			return "";
+		}
 		if ("https://w3id.org/lobid/rpb2".equals(sourceId)) {
 			source = "lbz " + getLbzId(uri);
 		} else if ("https://w3id.org/lobid/rpb".equals(sourceId)) {
@@ -247,10 +250,14 @@ public class Helper {
 			} else {
 				source = "ddc " + getDdcId(uri);
 			}
-		} else if ("http://d-nb.info/gnd/7749153-1".equals(sourceId)) {
+		} else if ("http://d-nb.info/gnd/7749153-1".equals(sourceId)
+				|| uri.startsWith("http://d-nb.info/gnd/")
+				|| uri.startsWith("https://d-nb.info/gnd/")) {
 			source = "gnd " + getGndId(uri);
 		} else if ("http://purl.org/lobid/nwbib".equals(sourceId)) {
 			source = "nwbib " + getNwbibId(uri);
+		} else if (uri.startsWith(Globals.protocol + Globals.server + "/adhoc")) {
+			source = "lokal";
 		}
 		return source;
 	}

--- a/app/views/Helper.java
+++ b/app/views/Helper.java
@@ -258,6 +258,9 @@ public class Helper {
 			source = "nwbib " + getNwbibId(uri);
 		} else if (uri.startsWith(Globals.protocol + Globals.server + "/adhoc")) {
 			source = "lokal";
+		} else if (uri.startsWith("http://aims.fao.org/aos/agrovoc")
+				|| uri.startsWith("https://aims.fao.org/aos/agrovoc")) {
+			source = "agrovoc";
 		}
 		return source;
 	}

--- a/app/views/tags/resourceView.scala.html
+++ b/app/views/tags/resourceView.scala.html
@@ -548,7 +548,7 @@
 		}
 		case list: List[Map[String,Object]] =>{
 			<tr class="egal">
-			    <td>
+			    <td class="subjectSource">
 	           	   Schlagwortfolge
 	           </td>
 			 	<td class="subject" style="text-align:left;">
@@ -566,7 +566,7 @@
 @displaySubject(id:String,label:String,roleId:String,roleName:String)={
 		
 			<tr class=@roleId>
-			    <td>
+			    <td  class="subjectSource">
 	           		@roleName
 	           </td>
 			 	<td class="subject" style="text-align:left;">


### PR DESCRIPTION
1.
Das Feld subjectName (dce:subject) wird zur Speicherung freier Schlagworte verwendet. In der neuen Artikelmaske gibt es das nicht mehr. 
Damit die alten Datensätze sich editieren lassen und homogen angezeigt werden, wird das Feld subjectName einfach dynamisch umgeschrieben zu subject (dc:subject). Dazu wird über die Adhoc-Schnittstelle ein Linked-Data-Eintrag emuliert.
2. 
Die Anzeige von Subjects erfolgt zweispaltig. Vorne steht die Quelle und die Notationsnummer (z.b. ddc 630) danach folgt die menschenlesbare Darstellung. Dies hat für GND-Subjects, die über die Artikelmaske angelinkt wurden, bislang nicht geklappt. Auch für lokale Anlinkungen liegt nun eine Lösung vor.