### PR TITLE
utilize more wpull-Parameters

### DIFF
--- a/app/helper/CrawlLog.java
+++ b/app/helper/CrawlLog.java
@@ -1,0 +1,70 @@
+/**
+ * 
+ */
+package helper;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import play.Logger;
+
+/**
+ * Java-Klasse für ein Crawl-Log. Z.Zt. nur für wpull-Crawls benutzt
+ * 
+ * @author I. Kuss
+ */
+public class CrawlLog {
+
+	private int exitStatus = -1;
+	private File logfile = null;
+
+	private static final Logger.ALogger WebgatherLogger =
+			Logger.of("webgatherer");
+
+	public int getExitStatus() {
+		return this.exitStatus;
+	}
+
+	/**
+	 * Konstruktor
+	 */
+	public CrawlLog(File logfile) {
+		this.exitStatus = -1;
+		this.logfile = logfile;
+	}
+
+	public void parse() {
+		this.exitStatus = -1;
+		BufferedReader buf = null;
+		String regExp = "^INFO Exiting with status ([0-9]+)";
+		Pattern pattern = Pattern.compile(regExp);
+		try {
+			buf = new BufferedReader(new FileReader(logfile));
+			String line = null;
+			while ((line = buf.readLine()) != null) {
+				Matcher matcher = pattern.matcher(line);
+				if (matcher.find()) {
+					this.exitStatus = Integer.parseInt(matcher.group(1));
+					break;
+				}
+			}
+		} catch (IOException e) {
+			WebgatherLogger
+					.warn("Crawler Exit Status cannot be defered from crawlLog "
+							+ logfile.getAbsolutePath() + "!", e.toString());
+		} finally {
+			try {
+				if (buf != null) {
+					buf.close();
+				}
+			} catch (IOException e) {
+				WebgatherLogger.warn("Read Buffer cannot be closed!");
+			}
+		}
+	}
+
+}

--- a/app/helper/WpullCrawl.java
+++ b/app/helper/WpullCrawl.java
@@ -67,6 +67,8 @@ public class WpullCrawl {
 
 	final static String jobDir =
 			Play.application().configuration().getString("regal-api.wpull.jobDir");
+	final static String tempJobDir = Play.application().configuration()
+			.getString("regal-api.wpull.tempJobDir");
 	final static String crawler =
 			Play.application().configuration().getString("regal-api.wpull.crawler");
 	final static String cdn =
@@ -301,6 +303,7 @@ public class WpullCrawl {
 		sb.append(" --convert-links"); // mandatory to rewrite relative urls
 		sb.append(" --warc-append"); // um CDN-Crawls und Haupt-Crawl im gleichen
 																	// Archiv zu bündeln
+		sb.append(" --warc-tempdir=" + tempJobDir);
 		return sb.toString();
 	}
 

--- a/conf/application.conf.tmpl
+++ b/conf/application.conf.tmpl
@@ -91,6 +91,7 @@ regal-api.restrictedweb.dataUrl="http://localhost/restrictedweb"
 #-------------wpull (Crawler)-----------------------                            
 regal-api.wpull.crawler="/usr/local/bin/wpull3"
 regal-api.wpull.jobDir="/opt/regal/wpull-data"
+regal-api.wpull.tempJobDir="/opt/regal/wpull-data-tempdir"
 regal-api.wpull.dataUrl="http://localhost"
 regal-api.public.jobDir="/opt/regal/public-data"
 

--- a/conf/application.conf.tmpl
+++ b/conf/application.conf.tmpl
@@ -90,8 +90,9 @@ regal-api.restrictedweb.dataUrl="http://localhost/restrictedweb"
 
 #-------------wpull (Crawler)-----------------------                            
 regal-api.wpull.crawler="/usr/local/bin/wpull3"
-regal-api.wpull.jobDir="/opt/regal/wpull-data"
+regal-api.wpull.jobDir="/opt/regal/wpull-data-crawldir"
 regal-api.wpull.tempJobDir="/opt/regal/wpull-data-tempdir"
+regal-api.wpull.outDir="/opt/regal/wpull-data"
 regal-api.wpull.dataUrl="http://localhost"
 regal-api.public.jobDir="/opt/regal/public-data"
 


### PR DESCRIPTION
Auf edoweb-dev funktioniert der Parameter --warc-tempdir. wpull baut dabei zunächst kleine Häppchen in einem gesonderten Verzeichnis auf, bevor es ins CrawlDir schreibt. Auf edoweb-dev habe ich das Temp-Verzeichnis /opt/regal/wpull-data-tempdir angelegt.
Kann aus meiner Sicht zusammengeführt werden.