### PR TITLE
Frl 366 metadataexport

### DIFF
--- a/app/views/resource.scala.html
+++ b/app/views/resource.scala.html
@@ -9,10 +9,6 @@
 						models.Globals.users.getUser(ctx())){
 
 			        		@tags.getTitle(hit.getLd2())
-                    <span>Export:</span>
-                    <a href="./@pid%2Ebibtex">BIBTEX</a> | <a href="./@pid%2Eend">ENDNOTE</a> | <a href="./@pid%2Eris">RIS</a> | <a href="./@pid%2Emods">MODS</a>
-
-
 					<ul class="nav nav-tabs">
 					 	<li class="active"><a href="#1a" data-toggle="tab">Object</a></li>
 					  	<li><a href="#2a" data-toggle="tab">Download</a></li>

--- a/app/views/resource.scala.html
+++ b/app/views/resource.scala.html
@@ -9,6 +9,10 @@
 						models.Globals.users.getUser(ctx())){
 
 			        		@tags.getTitle(hit.getLd2())
+                    <span>Export:</span>
+                    <a href="./@pid%2Ebibtex">BIBTEX</a> | <a href="./@pid%2Eend">ENDNOTE</a> | <a href="./@pid%2Eris">RIS</a> | <a href="./@pid%2Emods">MODS</a>
+
+
 					<ul class="nav nav-tabs">
 					 	<li class="active"><a href="#1a" data-toggle="tab">Object</a></li>
 					  	<li><a href="#2a" data-toggle="tab">Download</a></li>

--- a/app/views/tags/getTitle.scala.html
+++ b/app/views/tags/getTitle.scala.html
@@ -100,7 +100,12 @@
 					 }
 					 </p>
 					</h2>
-					
+<span>Metadaten exportieren:</span>
+<a href="/resource/@hit.get("@id")%2Ebibtex">BIBTEX</a> |
+<a href="/resource/@hit.get("@id")%2Eend">ENDNOTE</a> |
+<a href="/resource/@hit.get("@id")%2Eris">RIS</a> |
+<a href="/resource/@hit.get("@id")%2Emods">MODS</a>
+
 			</div>
 			
 		</div>


### PR DESCRIPTION
moved bibtex etc. links to different scala template. They should be visible directly beneath the title also in the drupal frontend