### PR TITLE
benutze wpull-Parameter --no-strong-redirects

### DIFF
--- a/app/helper/WpullCrawl.java
+++ b/app/helper/WpullCrawl.java
@@ -353,6 +353,7 @@ public class WpullCrawl {
 		sb.append(" --no-directories"); // mandatory to prevent runtime errors
 		sb.append(" --delete-after"); // mandatory for reducing required disc space
 		sb.append(" --convert-links"); // mandatory to rewrite relative urls
+		sb.append(" --no-strong-redirects"); // ohne diesen Parameter wird www.facebook.com, www.youtoube.com uvm. eingesammelt (aktiviert 12.05.2020)
 		sb.append(" --warc-append"); // um CDN-Crawls und Haupt-Crawl im gleichen
 																	// Archiv zu bündeln
 		sb.append(" --warc-tempdir=" + tempJobDir);


### PR DESCRIPTION
 Wenn man diesen Parameter **nicht** benutzt, wurden in letzer Zeit
Inhalte von www.facebook.com, www.youtube.com uvm. mit eingesammelt.
WARC-Files von unbescholtenen regionalen Sites gingen in den
zweistelligen Gigabytebereich und die Platte auf edoweb-rlp.de drohte
voll zu laufen. Testläufe zeigten, dass dieser Parameter dies verhindert.