### PR TITLE
added Links do metadata exports

### DIFF
--- a/app/views/tags/getTitle.scala.html
+++ b/app/views/tags/getTitle.scala.html
@@ -100,7 +100,13 @@
 					 }
 					 </p>
 					</h2>
-					
+
+<span>Metadaten exportieren:</span>
+<a href="https://@models.Globals.server/resource/@hit.get("@id")%2Ebibtex">BIBTEX</a> |
+<a href="https://@models.Globals.server/resource/@hit.get("@id")%2Eend">ENDNOTE</a> |
+<a href="https://@models.Globals.server/resource/@hit.get("@id")%2Eris">RIS</a> |
+<a href="https://@models.Globals.server/resource/@hit.get("@id")%2Emods">MODS</a>
+  
 			</div>
 			
 		</div>


### PR DESCRIPTION
the previous pull request was cancelt.
Now the links to the metadata formats are prefixed with the full servername. The previous relative links only worked in the api, but not via the drupal interface.