### PR TITLE
never return isOutstanding == true if a crawl is still running !!

### DIFF
--- a/app/helper/Webgatherer.java
+++ b/app/helper/Webgatherer.java
@@ -43,6 +43,8 @@ import models.Node;
 import actions.Create;
 import actions.Modify;
 import actions.Create.WebgathererTooBusyException;
+import helper.WpullCrawl.CrawlControllerState;
+import helper.WpullCrawl;
 import actions.Read;
 
 /**
@@ -187,7 +189,11 @@ public class Webgatherer implements Runnable {
 	private static boolean isOutstanding(Node n, Gatherconf conf) {
 		if (new Date().before(conf.getStartDate()))
 			return false;
-		// if a crawl job is still running, never return with true !!
+		// Falls ein Crawl noch läuft, gib nie `true` zurück !!
+		CrawlControllerState ccs = WpullCrawl.getCrawlControllerState(n);
+		if (ccs.equals(CrawlControllerState.RUNNING)) {
+			return false;
+		}
 		List<Link> parts = n.getRelatives(archive.fedora.FedoraVocabulary.HAS_PART);
 		if (parts == null || parts.isEmpty()) {
 			return true;


### PR DESCRIPTION
Nach-Entwicklung i.Zhg. mit EDOZWO-1020
Es wird seit Kurzem immer erst eine WebsiteVersion angelegt, wenn der Crawl erfolgreich war. Früher wurde generell und zuerst, am Anfang des Crawls, eine angelegt.
Wenn ein Crawl nun länger als 24 Std dauert kann es nun sein, dass ein zweiter Crawl angestoßen wird, obwohl der erste dann doch noch erfolgreich fertig wird.
Daher wird nun geprüft, ob ein Crawl noch läuft, bevor ein zweiter angestoßen wird. Wenn noch eine läuft, wird nie ein weiterer angestoßen.
Das sollte man sowieso machen !!!
Das Verfahren habe ich auf edoweb-dev getestet und es erfüllt seinen Zweck.
Wenn man absichtlich 2x kurz hintereinander den "nächtlichen" Crawl anstößt, werden beim zweiten Mal keine neuen Crawls mehr angestoßen.
Das System guckt in "ps -eaf | grep <crawler> | grep <URL>", ob aktuell ein Crawl zu der gegebenen URL läuft.