### PR TITLE
Edozwo 1026

### DIFF
--- a/app/helper/WpullCrawl.java
+++ b/app/helper/WpullCrawl.java
@@ -260,6 +260,7 @@ public class WpullCrawl {
 			wpullThread.setOutDir(resultDir);
 			wpullThread.setWarcFilename(warcFilename);
 			wpullThread.setLocalPath(localpath);
+			wpullThread.setExecArr(execArr);
 			wpullThread.setLogFile(log);
 			wpullThread.start();
 			exitState = wpullThread.getExitState();
@@ -363,7 +364,7 @@ public class WpullCrawl {
 		sb.append(" --convert-links"); // mandatory to rewrite relative urls
 		sb.append(" --no-strong-redirects"); // ohne diesen Parameter wird www.facebook.com, www.youtoube.com uvm. eingesammelt (aktiviert 12.05.2020)
 		sb.append(" --warc-append"); // um CDN-Crawls und Haupt-Crawl im gleichen Archiv zu bündeln
-		// sb.append(" --warc-tempdir=" + tempJobDir); auskommentiert 27.08.2020 für EDOZWO-1026
+	        // sb.append(" --warc-tempdir=" + tempJobDir); auskommentiert 27.08.2020 für EDOZWO-1026
 		sb.append(" --warc-move=" + resultDir);
 		return sb.toString();
 	}

--- a/app/helper/WpullCrawl.java
+++ b/app/helper/WpullCrawl.java
@@ -362,9 +362,8 @@ public class WpullCrawl {
 		sb.append(" --delete-after"); // mandatory for reducing required disc space
 		sb.append(" --convert-links"); // mandatory to rewrite relative urls
 		sb.append(" --no-strong-redirects"); // ohne diesen Parameter wird www.facebook.com, www.youtoube.com uvm. eingesammelt (aktiviert 12.05.2020)
-		sb.append(" --warc-append"); // um CDN-Crawls und Haupt-Crawl im gleichen
-																	// Archiv zu bündeln
-		sb.append(" --warc-tempdir=" + tempJobDir);
+		sb.append(" --warc-append"); // um CDN-Crawls und Haupt-Crawl im gleichen Archiv zu bündeln
+		// sb.append(" --warc-tempdir=" + tempJobDir); auskommentiert 27.08.2020 für EDOZWO-1026
 		sb.append(" --warc-move=" + resultDir);
 		return sb.toString();
 	}

--- a/app/helper/WpullThread.java
+++ b/app/helper/WpullThread.java
@@ -157,40 +157,12 @@ public class WpullThread extends Thread {
 			WebgatherLogger.info("Webcrawl for " + conf.getName()
 					+ " exited with exitState " + exitState);
 			proc.destroy();
-			if (exitState == 0) {
+			if (exitState == 0 || exitState == 4 || exitState == 8) {
 				new Create().createWebpageVersion(node, conf, outDir, localpath);
-				return;
+				WebgatherLogger
+						.info("WebpageVersion für " + conf.getName() + "wurde angelegt.");
 			}
-			// Keep warc file of failed crawl
-			File warcFile =
-					new File(crawlDir.toString() + "/" + warcFilename + ".warc.gz");
-			File warcFileAttempted = new File(crawlDir.toString() + "/" + warcFilename
-					+ ".warc.gz.attempt" + attempt);
-			warcFile.renameTo(warcFileAttempted);
-			warcFile.delete();
-			attempt++;
-			if (attempt > maxNumberAttempts) {
-				throw new RuntimeException("Webcrawl für " + conf.getName()
-						+ " fehlgeschlagen: Maximale Anzahl Versuche überschritten !");
-			}
-			// Crawl wird erneut angestoßen; rekursiver Aufruf von wpullThread.start()
-			WebgatherLogger.info("Webcrawl for " + conf.getName()
-					+ " wird erneut angestoßen. " + attempt + ". Versuch.");
-			ProcessBuilder pb_attempt = new ProcessBuilder(execArr);
-			assert crawlDir.isDirectory();
-			pb_attempt.directory(crawlDir);
-			pb_attempt.redirectErrorStream(true);
-			pb_attempt.redirectOutput(ProcessBuilder.Redirect.appendTo(logFile));
-			WpullThread wpullThread = new WpullThread(pb_attempt, attempt);
-			wpullThread.setNode(node);
-			wpullThread.setConf(conf);
-			wpullThread.setCrawlDir(crawlDir);
-			wpullThread.setOutDir(outDir);
-			wpullThread.setWarcFilename(warcFilename);
-			wpullThread.setLocalPath(localpath);
-			wpullThread.setExecArr(execArr);
-			wpullThread.setLogFile(logFile);
-			wpullThread.start();
+			return;
 		} catch (Exception e) {
 			WebgatherLogger.error(e.toString());
 			throw new RuntimeException("wpull crawl not successfully started!", e);


### PR DESCRIPTION
don't re-attempt failed crawls on the same day
  Failed crawls will be re-attempted on the next day. In this way one avoids java programming with recursive Threads.

don't use wpull parameter warc-tempdir anymore. This parameter is not needed anymore, since we are using wpull parameter warc-move and thus have separate directories for crawling and storing the finished crawl, anyway

