### PR TITLE
Edozwo 1047

### DIFF
--- a/app/actions/Read.java
+++ b/app/actions/Read.java
@@ -105,6 +105,33 @@ public class Read extends RegalAction {
 		}
 	}
 
+	/**
+	 * Liefert das zuletzt modifizierte Kind vom Type "contentType". Wie
+	 * getLastModifiedChild, jedoch wir Null zurück gegeben, falls: - der
+	 * Inhaltstyp leer ist, oder - kein Kind von dem gewünschten Inhaltstyp
+	 * gefunden wurde. Die Methode getLastModifiedChild liefert dagegen in diesem
+	 * Falle ein Kind irgendeinen Types bzw. den Knoten selber.
+	 * 
+	 * @param node Der Knoten, dessen Kinder gesucht werden.
+	 * @param contentType der Inhaltstyp, von dem das Kind sein muss.
+	 * @return node
+	 */
+	public Node getLastModifiedChildOrNull(Node node, String contentType) {
+		if (contentType == null || contentType.isEmpty()) {
+			return null;
+		}
+		Node oldestNode = null;
+		for (Node n : getParts(node)) {
+			if (contentType.equals(n.getContentType())) {
+				oldestNode = compareDates(n, oldestNode);
+			}
+		}
+		if (oldestNode == null)
+			return null;
+		return oldestNode;
+
+	}
+
 	private Node compareDates(Node currentNode, Node oldestNode) {
 		Date currentNodeDate = currentNode.getObjectTimestamp();
 		if (currentNodeDate == null)
@@ -748,8 +775,9 @@ public class Read extends RegalAction {
 						.equals(Gatherconf.CrawlerSelection.wpull)) {
 					entries.put("crawlControllerState",
 							WpullCrawl.getCrawlControllerState(node));
-					entries.put("crawlExitStatus", WpullCrawl.getCrawlExitStatus(node) < 0
-							? "" : WpullCrawl.getCrawlExitStatus(node));
+					entries.put("crawlExitStatus",
+							WpullCrawl.getCrawlExitStatus(node) < 0 ? ""
+									: WpullCrawl.getCrawlExitStatus(node));
 				}
 				/*
 				 * Launch Count als Summe der Launches über alle Crawler ermitteln -

--- a/app/helper/Webgatherer.java
+++ b/app/helper/Webgatherer.java
@@ -169,7 +169,8 @@ public class Webgatherer implements Runnable {
 	 * @throws Exception Ausnahme beim Lesen
 	 */
 	public static Date getLastLaunch(Node n) throws Exception {
-		Node lastModifiedChild = new Read().getLastModifiedChild(n, "version");
+		Node lastModifiedChild =
+				new Read().getLastModifiedChildOrNull(n, "version");
 		if (lastModifiedChild == null)
 			return null;
 		return lastModifiedChild.getLastModified();

--- a/app/helper/Webgatherer.java
+++ b/app/helper/Webgatherer.java
@@ -160,12 +160,16 @@ public class Webgatherer implements Runnable {
 	}
 
 	/**
+	 * Diese Methode ermittelt das Datum, an dem zuletzt erfolgreich ein
+	 * Webschnitt an die Webpage angehängt wurde.
+	 * 
 	 * @param n der Knoten für die Webpage
-	 * @return Datum+Zeit (Typ Date), als zuletzt ein Crawl angestoßen wurde
+	 * @return Datum+Zeit (Typ Date) des letzten erfolgreich beendeten Webcrwals =
+	 *         Änderungsdatum des neuesten Webschnitts
 	 * @throws Exception Ausnahme beim Lesen
 	 */
 	public static Date getLastLaunch(Node n) throws Exception {
-		return new Read().getLastModifiedChild(n, (Node) null).getLastModified();
+		return new Read().getLastModifiedChild(n, "version").getLastModified();
 	}
 
 	/**

--- a/app/helper/Webgatherer.java
+++ b/app/helper/Webgatherer.java
@@ -169,7 +169,10 @@ public class Webgatherer implements Runnable {
 	 * @throws Exception Ausnahme beim Lesen
 	 */
 	public static Date getLastLaunch(Node n) throws Exception {
-		return new Read().getLastModifiedChild(n, "version").getLastModified();
+		Node lastModifiedChild = new Read().getLastModifiedChild(n, "version");
+		if (lastModifiedChild == null)
+			return null;
+		return lastModifiedChild.getLastModified();
 	}
 
 	/**


### PR DESCRIPTION
Bei der Durchsicht der Webschnitte (Qualitätskontrolle) war mir aufgefallen, dass z.B. edoweb:261 nicht erneut gesammelt wird, obwohl schon seit längerer Zeit kein Webschnitt mehr erfolgreich angelegt worden war.
Den Grund habe ich darin erkannt, dass das System bei der Ermittlung des "letzten Crawl-Datums" Einverständniserklärungen nicht von Webcrawls unterscheidet !
Dieser Pull-Request behebt dieses Problem.
Den PR habe ich auf edoweb-dev getestet, Beispiel-Webpage: https://edoweb-dev.hbz-nrw.de/resource/edoweb%3A10416