### PR TITLE
Edozwo 1022

### DIFF
--- a/app/archive/fedora/FedoraFacade.java
+++ b/app/archive/fedora/FedoraFacade.java
@@ -381,6 +381,8 @@ public class FedoraFacade {
 	 */
 	public void updateNode(Node node) {
 		play.Logger.info("Update node in fedora");
+		play.Logger.debug("node access scheme: " + node.getAccessScheme());
+		play.Logger.debug("node publish scheme: " + node.getPublishScheme());
 		DublinCoreHandler.updateDc(node);
 		List<Transformer> models = node.getTransformer();
 		// utils.updateContentModels(models);

--- a/app/controllers/Resource.java
+++ b/app/controllers/Resource.java
@@ -1116,6 +1116,7 @@ public class Resource extends MyController {
 
 	public static Promise<Result> createVersion(@PathParam("pid") String pid) {
 		try {
+			play.Logger.debug("Starting Resource.createVersion()");
 			Node node = readNodeOrNull(pid);
 			Gatherconf conf = Gatherconf.create(node.getConf());
 			if (conf.hasUrlMoved(node)) {

--- a/app/models/Gatherconf.java
+++ b/app/models/Gatherconf.java
@@ -506,7 +506,9 @@ public class Gatherconf {
 		} // keine erneute Prüfung
 		HttpURLConnection httpConnection = (HttpURLConnection) new URL(
 				WebgatherUtils.convertUnicodeURLToAscii(url)).openConnection();
+		httpConnection.setInstanceFollowRedirects(false);
 		httpConnection.setRequestMethod("GET");
+		httpConnection.connect();
 		httpResponseCode = httpConnection.getResponseCode();
 		play.Logger.debug("HTTP Response Code: " + httpResponseCode);
 		if (httpResponseCode != 301) {

--- a/app/models/Gatherconf.java
+++ b/app/models/Gatherconf.java
@@ -500,6 +500,7 @@ public class Gatherconf {
 	public boolean hasUrlMoved(Node node)
 			throws URISyntaxException, MalformedURLException, IOException {
 
+		play.Logger.debug("Starting hasUrlMoved");
 		if (invalidUrl) {
 			return true;
 		} // keine erneute Prüfung
@@ -507,6 +508,7 @@ public class Gatherconf {
 				WebgatherUtils.convertUnicodeURLToAscii(url)).openConnection();
 		httpConnection.setRequestMethod("GET");
 		httpResponseCode = httpConnection.getResponseCode();
+		play.Logger.debug("HTTP Response Code: " + httpResponseCode);
 		if (httpResponseCode != 301) {
 			return false;
 		}
@@ -519,6 +521,7 @@ public class Gatherconf {
 				urlNew = header.getValue().get(0);
 			}
 		}
+		play.Logger.debug("urlNew: " + urlNew);
 		httpConnection.disconnect();
 		new Modify().updateConf(node, this.toString());
 		return true;


### PR DESCRIPTION
This fixes EDOZWO-10222
Thanks to https://stackoverflow.com/questions/2659000/java-how-to-find-the-redirected-url-of-a-url !
Without the "httpConnection.setInstanceFollowRedirects(false);" I get a 200 even for moved sites ! Now it returns a 301, as desired.
Use case: https://edoweb-dev.hbz-nrw.de/resource/edoweb%3A10479
www.peppix.de moved to www.naturraum-stux.de
Crawl will not be started, but system asks for confirmation of the new URL (as desired).