### PR TITLE
Add type element4 old resources at amb datastream

### DIFF
--- a/app/helper/LRMIMapper.java
+++ b/app/helper/LRMIMapper.java
@@ -160,10 +160,16 @@ public class LRMIMapper {
 
 			if (rdf.containsKey("contentType")) {
 				iterator = getLobid2Iterator(rdf.get("contentType"));
+				play.Logger.debug("rdf.get(contentType) =" + rdf.get("contentType"));
+				play.Logger.debug("iterator =" + iterator.toString());
 				arr = new JSONArray();
 				while (iterator.hasNext()) {
 					arr.put(iterator.next());
 				}
+				lrmiJsonContent.put("type", arr);
+			} else {
+				arr = new JSONArray();
+				arr.put("LearningResource");
 				lrmiJsonContent.put("type", arr);
 			}
 

--- a/app/helper/LRMIMapper.java
+++ b/app/helper/LRMIMapper.java
@@ -168,6 +168,8 @@ public class LRMIMapper {
 				}
 				lrmiJsonContent.put("type", arr);
 			} else {
+				// dieser Fall sollte nie vorkommen, da "contentType" ja immer gesetzt sein sollte.
+				// falls der Fall doch vorkommt, wird AMB-"type" jetzt gesetzt.
 				arr = new JSONArray();
 				arr.put("LearningResource");
 				lrmiJsonContent.put("type", arr);


### PR DESCRIPTION
Es ist erwünscht (Tobias Bülte), dass alle Ressourcen (alt wie neu) in deren Amb-Datenstrom ein "type": ["LearningResource"] enthalten.