### PR TITLE
Edit language at metadata2 from deu to ger

### DIFF
--- a/app/helper/Metadata2Helper.java
+++ b/app/helper/Metadata2Helper.java
@@ -66,6 +66,12 @@ public class Metadata2Helper {
 					Map<String, Object> languageMap = new LinkedHashMap<>();
 					JSONObject jo = jsArr.getJSONObject(i);
 					languageMap.put("prefLabel", jo.getString("prefLabel"));
+					if (jo.getString("@id").contains("/iso639-2/deu")) {
+						String editlanguage = "http://id.loc.gov/vocabulary/iso639-2/ger";
+						languageMap.put("@id", editlanguage);
+					} else {
+						languageMap.put("@id", jo.getString("@id"));
+					}
 					languageMap.put("@id", jo.getString("@id"));
 					langList.add(languageMap);
 

--- a/app/helper/Metadata2Helper.java
+++ b/app/helper/Metadata2Helper.java
@@ -72,7 +72,6 @@ public class Metadata2Helper {
 					} else {
 						languageMap.put("@id", jo.getString("@id"));
 					}
-					languageMap.put("@id", jo.getString("@id"));
 					langList.add(languageMap);
 
 				}


### PR DESCRIPTION
In this branch the language at metadata2 is edited from 'deu' to 'ger' and persisted, so that the combobox language in FrontEnd shows the language German selected.