### PR TITLE
Persist ktbl datastream by master

### DIFF
--- a/app/actions/Delete.java
+++ b/app/actions/Delete.java
@@ -173,7 +173,7 @@ public class Delete extends RegalAction {
 				RDFFormat.NTRIPLES);
 		Collection<Statement> myGraph =
 				RdfUtils.deletePredicateFromRepo(rdfRepo, pred);
-		return new Modify().updateMetadata2(node,
+		return new Modify().updateMetadata("metadata2", node,
 				RdfUtils.graphToString(myGraph, RDFFormat.NTRIPLES));
 	}
 }

--- a/app/actions/Enrich.java
+++ b/app/actions/Enrich.java
@@ -62,7 +62,7 @@ public class Enrich {
 			List<Statement> enrichStatements = new ArrayList<>();
 			enrichAll(node, metadata, enrichStatements);
 			metadata = RdfUtils.replaceTriples(enrichStatements, metadata);
-			new Modify().updateMetadata2(node, metadata);
+			new Modify().updateMetadata("metadata2", node, metadata);
 		} catch (Exception e) {
 			play.Logger.debug("", e);
 			return "Enrichment of " + node.getPid() + " partially failed !\n"

--- a/app/actions/Modify.java
+++ b/app/actions/Modify.java
@@ -236,13 +236,13 @@ public class Modify extends RegalAction {
 			String alephid =
 					lobidUri.replaceFirst("http://lobid.org/resource[s]*/", "");
 			content = getLobid2DataAsNtripleString(node, alephid);
-			updateMetadata2(node, content);
+			updateMetadata("metadata2", node, content);
 
 			String enrichMessage2 = Enrich.enrichMetadata2(node);
 			return pid + " metadata successfully updated, lobidified and enriched! "
 					+ enrichMessage2;
 		} else {
-			updateMetadata2(node, content);
+			updateMetadata("metadata2", node, content);
 			String enrichMessage2 = Enrich.enrichMetadata2(node);
 			return pid + " metadata successfully updated, and enriched! "
 					+ enrichMessage2;
@@ -272,13 +272,13 @@ public class Modify extends RegalAction {
 					lobidUri.replaceFirst("http://lobid.org/resource[s]*/", "");
 			alephid = alephid.replaceAll("#.*", "");
 			content = getLobid2DataAsNtripleString(node, alephid);
-			updateMetadata2(node, content);
+			updateMetadata("metadata2", node, content);
 
 			String enrichMessage = Enrich.enrichMetadata2(node);
 			return pid + " metadata successfully updated, lobidified and enriched! "
 					+ enrichMessage;
 		} else {
-			updateMetadata2(node, content);
+			updateMetadata("metadata2", node, content);
 			String enrichMessage = Enrich.enrichMetadata2(node);
 			return pid + " metadata successfully updated, and enriched! "
 					+ enrichMessage;
@@ -312,7 +312,7 @@ public class Modify extends RegalAction {
 			Map<String, Object> rdf = new XmlUtils().getLd2Lobidify2DeepGreen(
 					node.getLd2(), embargoDuration, deepgreenId, content);
 			play.Logger.debug("Mapped DeepGrren data to lobid2!");
-			updateMetadata2(node, rdfToString(rdf, format));
+			updateMetadata("metadata2", node, rdfToString(rdf, format));
 			play.Logger.debug("Updated Metadata2 datastream!");
 
 			String enrichMessage = Enrich.enrichMetadata2(node);
@@ -359,7 +359,7 @@ public class Modify extends RegalAction {
 			try {
 				content = getLobid2DataAsNtripleStringIfResourceHasRecentlyChanged(node,
 						alephid, date);
-				updateMetadata2(node, content);
+				updateMetadata("metadata2", node, content);
 				msg.append(Enrich.enrichMetadata2(node));
 			} catch (NotUpdatedException e) {
 				play.Logger.debug("", e);
@@ -1104,40 +1104,41 @@ public class Modify extends RegalAction {
 	}
 
 	public String lobidify2(Node node, String alephid) {
-		updateMetadata2(node, getLobid2DataAsNtripleString(node, alephid));
+		updateMetadata("metadata2", node,
+				getLobid2DataAsNtripleString(node, alephid));
 		String enrichMessage = Enrich.enrichMetadata2(node);
 		return enrichMessage;
 	}
 
-	String updateMetadata2(Node node, String content) {
-		try {
-			String pid = node.getPid();
-			play.Logger.debug("Updating Metadata2 of PID " + pid);
-			play.Logger.debug("content: " + content);
-			if (content == null) {
-				throw new HttpArchiveException(406,
-						pid + " You've tried to upload an empty string."
-								+ " This action is not supported."
-								+ " Use HTTP DELETE instead.\n");
-			}
-			// RdfUtils.validate(content);
-			// Extreme Workaround to fix subject uris
-			content = rewriteContent(content, pid);
-			// Workaround end
-			File file = CopyUtils.copyStringToFile(content);
-			play.Logger
-					.debug("content.file.getAbsolutePath():" + file.getAbsolutePath());
-			node.setMetadata2File(file.getAbsolutePath());
-			node.setMetadata2(content);
-			OaiDispatcher.makeOAISet(node);
-			reindexNodeAndParent(node);
-			return pid + " metadata2 successfully updated!";
-		} catch (RdfException e) {
-			throw new HttpArchiveException(400, e);
-		} catch (IOException e) {
-			throw new UpdateNodeException(e);
-		}
-	}
+	// public String updateMetadata2(Node node, String content) {
+	// try {
+	// String pid = node.getPid();
+	// play.Logger.debug("Updating Metadata2 of PID " + pid);
+	// play.Logger.debug("content: " + content);
+	// if (content == null) {
+	// throw new HttpArchiveException(406,
+	// pid + " You've tried to upload an empty string."
+	// + " This action is not supported."
+	// + " Use HTTP DELETE instead.\n");
+	// }
+	// // RdfUtils.validate(content);
+	// // Extreme Workaround to fix subject uris
+	// content = rewriteContent(content, pid);
+	// // Workaround end
+	// File file = CopyUtils.copyStringToFile(content);
+	// play.Logger
+	// .debug("content.file.getAbsolutePath():" + file.getAbsolutePath());
+	// node.setMetadata2File(file.getAbsolutePath());
+	// node.setMetadata2(content);
+	// OaiDispatcher.makeOAISet(node);
+	// reindexNodeAndParent(node);
+	// return pid + " metadata2 successfully updated!";
+	// } catch (RdfException e) {
+	// throw new HttpArchiveException(400, e);
+	// } catch (IOException e) {
+	// throw new UpdateNodeException(e);
+	// }
+	// }
 
 	private static String getAuthorOrdering(Node node) {
 		try (InputStream in =
@@ -1232,6 +1233,11 @@ public class Modify extends RegalAction {
 								+ " This action is not supported."
 								+ " Use HTTP DELETE instead.\n");
 			}
+
+			if (metadataType.equals("metadata2")) {
+				content = rewriteContent(content, pid);
+			}
+
 			File file = CopyUtils.copyStringToFile(content);
 			play.Logger
 					.debug("content.file.getAbsolutePath():" + file.getAbsolutePath());

--- a/app/archive/fedora/FedoraFacade.java
+++ b/app/archive/fedora/FedoraFacade.java
@@ -397,16 +397,26 @@ public class FedoraFacade {
 			}
 			play.Logger.debug("Updated stream");
 		}
+		//
+		// if (node.getMetadataFile("metadata") != null) {
+		// utils.updateMetadataStream(node, "metadata");
+		// }
 
-		if (node.getMetadataFile("metadata") != null) {
-			utils.updateMetadataStream(node, "metadata");
+		if (node.getMetadataFile("metadata2") != null) {
+			utils.updateMetadata2Stream(node);
 		}
+
 		if (node.getMetadataFile("toscience") != null) {
 			utils.updateMetadataJsonStream(node);
 		}
-		if (node.getMetadata2File() != null) {
-			utils.updateMetadata2Stream(node);
+
+		if (node.getMetadataFile("ktbl") != null) {
+			utils.updateMetadataKtblStream(node);
 		}
+
+		// if (node.getMetadata2File() != null) {
+		// utils.updateMetadata2Stream(node);
+		// }
 		if (node.getSeqFile() != null) {
 			utils.updateSeqStream(node);
 		}

--- a/app/archive/fedora/Utils.java
+++ b/app/archive/fedora/Utils.java
@@ -520,21 +520,27 @@ public class Utils {
 	}
 
 	void updateMetadata2Stream(Node node) {
-		try {
-			File file = new File(node.getMetadata2File());
-			if (dataStreamExists(node.getPid(), "metadata2")) {
-				new ModifyDatastream(node.getPid(), "metadata2").versionable(true)
-						.dsLabel("n-triple rdf metadata2").dsState("A").controlGroup("M")
-						.mimeType("text/plain").content(file).execute();
-			} else {
-				new AddDatastream(node.getPid(), "metadata2").versionable(true)
-						.dsState("A").dsLabel("n-triple rdf metadata2").controlGroup("M")
-						.mimeType("text/plain").content(file).execute();
-			}
-		} catch (FedoraClientException e) {
-			throw new HttpArchiveException(e.getStatus(), e);
-		}
+		updateMetadataStream(archive.fedora.Vocabulary.metadata2, "text/plain",
+				"n-triple rdf metadata", node);
 	}
+
+	//
+	// void updateMetadata2Stream(Node node) {
+	// try {
+	// File file = new File(node.getMetadata2File());
+	// if (dataStreamExists(node.getPid(), "metadata2")) {
+	// new ModifyDatastream(node.getPid(), "metadata2").versionable(true)
+	// .dsLabel("n-triple rdf metadata2").dsState("A").controlGroup("M")
+	// .mimeType("text/plain").content(file).execute();
+	// } else {
+	// new AddDatastream(node.getPid(), "metadata2").versionable(true)
+	// .dsState("A").dsLabel("n-triple rdf metadata2").controlGroup("M")
+	// .mimeType("text/plain").content(file).execute();
+	// }
+	// } catch (FedoraClientException e) {
+	// throw new HttpArchiveException(e.getStatus(), e);
+	// }
+	// }
 
 	void readRelsExt(Node node) throws FedoraClientException {
 		FedoraResponse response =
@@ -991,8 +997,13 @@ public class Utils {
 	}
 
 	void updateMetadataJsonStream(Node node) {
-		updateMetadataStream(archive.fedora.Vocabulary.metadataJson,
-				"application/json", "Metadata in Format JSON", node);
+		updateMetadataStream(archive.fedora.Vocabulary.toscience,
+				"application/json", "Metadata TOSCIENCE in Format JSON", node);
+	}
+
+	void updateMetadataKtblStream(Node node) {
+		updateMetadataStream(archive.fedora.Vocabulary.ktbl, "application/json",
+				"Metadata KTBL in Format JSON", node);
 	}
 
 	public void updateMetadataStream(String metadataType, String mimeType,

--- a/app/archive/fedora/Vocabulary.java
+++ b/app/archive/fedora/Vocabulary.java
@@ -131,6 +131,7 @@ public abstract class Vocabulary {
 
 	public final static String metadata2 = "metadata2";
 	public final static String lrmiData = "lrmiData";
-	public final static String metadataJson = "toscience";
+	public final static String toscience = "toscience";
+	public final static String ktbl = "ktbl";
 
 }

--- a/app/controllers/Resource.java
+++ b/app/controllers/Resource.java
@@ -1492,6 +1492,7 @@ public class Resource extends MyController {
 		return new CreateAction().call(userId -> {
 			try {
 				DynamicForm form = Form.form().bindFromRequest();
+				String alephId = form.get("alephId");
 				String namespace = form.get("namespace");
 				String pid = form.get("pid");
 				ToScienceObject object = new ToScienceObject();

--- a/app/controllers/Resource.java
+++ b/app/controllers/Resource.java
@@ -545,16 +545,19 @@ public class Resource extends MyController {
 
 	@ApiOperation(produces = "application/json", nickname = "updateKtbl", value = "updateKtbl", notes = "Updates the ktbl datastream of a resource.", response = Message.class, httpMethod = "PUT")
 	@ApiImplicitParams({
-			@ApiImplicitParam(name = "data", dataType = "file", required = true, paramType = "body") })
+			@ApiImplicitParam(name = "data", value = "data", dataType = "file", required = true, paramType = "body") })
 	public static Promise<Result> updateKtbl(@PathParam("pid") String pid) {
 		return new ModifyAction().call(pid, node -> {
 			try {
-
+				play.Logger.debug("Starting updateKtbl");
 				String ktblContent = null;
 				Node readNode = new Read().readNode(pid);
 
 				MultipartFormData body = request().body().asMultipartFormData();
+
+				play.Logger.debug("getFile");
 				FilePart data = body.getFile("data");
+				play.Logger.debug("getFile done");
 
 				if (data == null) {
 					return (Result) JsonMessage(new Message("Missing File.", 400));

--- a/app/controllers/Resource.java
+++ b/app/controllers/Resource.java
@@ -549,21 +549,17 @@ public class Resource extends MyController {
 	public static Promise<Result> updateKtbl(@PathParam("pid") String pid) {
 		return new ModifyAction().call(pid, node -> {
 			try {
-				play.Logger.debug("Starting updateKtbl");
-				String ktblContent = null;
+
+				play.Logger.debug("Starting KTBL Mapping");
+
 				Node readNode = new Read().readNode(pid);
 
 				MultipartFormData body = request().body().asMultipartFormData();
-
-				play.Logger.debug("getFile");
 				FilePart data = body.getFile("data");
-				play.Logger.debug("getFile done");
 
 				if (data == null) {
 					return (Result) JsonMessage(new Message("Missing File.", 400));
 				}
-				play.Logger.debug("Starting updateKtbl data with pid=" + pid);
-				play.Logger.debug("request().body().asJson()=" + data.toString());
 
 				/**
 				 * 1.KTBL(Json)***************************************
@@ -578,29 +574,30 @@ public class Resource extends MyController {
 
 				String result1 = modify.updateMetadata("ktbl", readNode, ktblMetadata);
 
+				play.Logger.debug("Done KTBL Mapping");
+
 				/**
 				 * 2. TOSCIENCE(Json)***************************************
 				 */
 
-				String result2 =
-						modify.updateMetadata("toscience", readNode, ktblMetadata);
+				// String result2 =
+				// modify.updateMetadata("toscience", readNode, ktblMetadata);
 
 				/**
 				 * 3. METADATA2(rdf)***************************************
 				 */
-				JSONObject ktblJson = new JSONObject(ktblMetadata);
-				Map<String, Object> rdf =
-						KTBLMapperHelper.getMapFromJSONObject(ktblJson);
-
-				String contentRewrite = modify.rewriteContent(rdf.toString(), pid);
-
-				String result3 =
-						modify.updateMetadata("metadata2", readNode, contentRewrite);
+				// JSONObject ktblJson = new JSONObject(ktblMetadata);
+				// Map<String, Object> rdf =
+				// KTBLMapperHelper.getMapFromJSONObject(ktblJson);
+				//
+				// String contentRewrite = modify.rewriteContent(rdf.toString(), pid);
+				//
+				// String result3 =
+				// modify.updateMetadata("metadata2", readNode, contentRewrite);
 
 				Globals.fedora.updateNode(readNode);
 
-				return JsonMessage(
-						new Message(result1 + "\n" + result2 + "\n" + result3));
+				return JsonMessage(new Message(result1));
 			} catch (Exception e) {
 				throw new HttpArchiveException(500, e);
 			}

--- a/app/controllers/Resource.java
+++ b/app/controllers/Resource.java
@@ -554,7 +554,7 @@ public class Resource extends MyController {
 				Node readNode = new Read().readNode(pid);
 
 				MultipartFormData body = request().body().asMultipartFormData();
-				FilePart data = body.getFile("data");
+				FilePart data = body.getFile("Metadata");
 
 				if (data == null) {
 					return (Result) JsonMessage(new Message("Missing File.", 400));

--- a/app/controllers/Resource.java
+++ b/app/controllers/Resource.java
@@ -545,7 +545,7 @@ public class Resource extends MyController {
 
 	@ApiOperation(produces = "application/json", nickname = "updateKtbl", value = "updateKtbl", notes = "Updates the ktbl datastream of a resource.", response = Message.class, httpMethod = "PUT")
 	@ApiImplicitParams({
-			@ApiImplicitParam(value = "Metadata", dataType = "file", required = true, paramType = "body") })
+			@ApiImplicitParam(name = "data", dataType = "file", required = true, paramType = "body") })
 	public static Promise<Result> updateKtbl(@PathParam("pid") String pid) {
 		return new ModifyAction().call(pid, node -> {
 			try {
@@ -554,7 +554,7 @@ public class Resource extends MyController {
 				Node readNode = new Read().readNode(pid);
 
 				MultipartFormData body = request().body().asMultipartFormData();
-				FilePart data = body.getFile("Metadata");
+				FilePart data = body.getFile("data");
 
 				if (data == null) {
 					return (Result) JsonMessage(new Message("Missing File.", 400));

--- a/app/helper/KTBLMapperHelper.java
+++ b/app/helper/KTBLMapperHelper.java
@@ -47,7 +47,10 @@ public class KTBLMapperHelper {
 			e.printStackTrace();
 		} finally {
 			if (br != null) {
-				br.close();
+				try {
+					br.close();
+				} catch (IOException e) {
+				}
 			}
 		}
 		play.Logger.debug("ktblMetadata.toString()=" + ktblMetadata.toString());

--- a/app/helper/KTBLMapperHelper.java
+++ b/app/helper/KTBLMapperHelper.java
@@ -3,6 +3,11 @@ package helper;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import org.json.JSONObject;
 import play.mvc.Http.MultipartFormData.FilePart;
 
@@ -56,6 +61,27 @@ public class KTBLMapperHelper {
 		wantedKtblMetadata.put("info", allKtblMetadata.get("info"));
 
 		return wantedKtblMetadata.toString();
+	}
+
+	/**
+	 * This method converts a JSONObject into a Map<String, Object>
+	 * 
+	 * @param jsonObject
+	 * @return
+	 */
+
+	public static Map<String, Object> getMapFromJSONObject(
+			JSONObject jsonObject) {
+		Map<String, Object> map = new LinkedHashMap<>();
+
+		Iterator<String> keys = jsonObject.keys();
+		while (keys.hasNext()) {
+			String key = keys.next();
+			Object value = jsonObject.get(key);
+			map.put(key, value);
+		}
+
+		return map;
 	}
 
 }

--- a/app/helper/KTBLMapperHelper.java
+++ b/app/helper/KTBLMapperHelper.java
@@ -1,0 +1,61 @@
+package helper;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import org.json.JSONObject;
+import play.mvc.Http.MultipartFormData.FilePart;
+
+/**
+ * 
+ * @author adoud
+ *
+ */
+public class KTBLMapperHelper {
+
+	/**
+	 * This method gets the content of a FilePart(Json File) and returns it as a
+	 * string
+	 * 
+	 * @param fp
+	 * @return the content of the file as a string
+	 */
+	static public String getStringContentFromJsonFile(FilePart fp) {
+		StringBuilder ktblMetadata = new StringBuilder();
+
+		if (fp != null) {
+			play.Logger.debug("FilePart !=NULL");
+			File file = (File) fp.getFile();
+			try (BufferedReader br = new BufferedReader(new FileReader(file))) {
+				String line;
+				while ((line = br.readLine()) != null) {
+					ktblMetadata.append(line);
+				}
+			}
+		}
+		play.Logger.debug("ktblMetadata.toString()=" + ktblMetadata.toString());
+		return ktblMetadata.toString();
+	}
+
+	/**
+	 * The method gets the required KTBL metadata from the json file and returns
+	 * it as a string
+	 * 
+	 * @param allKtblMetadata
+	 * @return required KTBL metadata, which must be persisted
+	 */
+	static public String getToPersistKtblMetadata(String contentJsFile) {
+
+		JSONObject allKtblMetadata = new JSONObject(contentJsFile);
+		JSONObject wantedKtblMetadata = new JSONObject();
+
+		wantedKtblMetadata.put("recordingPeriod",
+				allKtblMetadata.getJSONArray("recordingPeriod"));
+		wantedKtblMetadata.put("relatedDatasets",
+				allKtblMetadata.getJSONArray("relatedDatasets"));
+		wantedKtblMetadata.put("info", allKtblMetadata.get("info"));
+
+		return wantedKtblMetadata.toString();
+	}
+
+}

--- a/app/helper/KTBLMapperHelper.java
+++ b/app/helper/KTBLMapperHelper.java
@@ -43,6 +43,8 @@ public class KTBLMapperHelper {
 			}
 		} catch (FileNotFoundException e) {
 			e.printStackTrace();
+		} catch (IOException e) {
+			e.printStackTrace();
 		} finally {
 			if (br != null) {
 				br.close();

--- a/app/helper/KTBLMapperHelper.java
+++ b/app/helper/KTBLMapperHelper.java
@@ -11,6 +11,7 @@ import java.io.FileNotFoundException;
 import org.json.JSONObject;
 import play.mvc.Http.MultipartFormData.FilePart;
 import org.json.JSONException;
+import java.io.IOException;
 
 /**
  * 
@@ -27,23 +28,25 @@ public class KTBLMapperHelper {
 	 * @return the content of the file as a string
 	 */
 	static public String getStringContentFromJsonFile(FilePart fp) {
-
 		StringBuilder ktblMetadata = null;
+		BufferedReader br = null;
+
 		try {
 			ktblMetadata = new StringBuilder();
 			if (fp != null) {
-				play.Logger.debug("FilePart !=NULL");
 				File file = (File) fp.getFile();
-				try (BufferedReader br = new BufferedReader(new FileReader(file))) {
-					String line;
-					while ((line = br.readLine()) != null) {
-						ktblMetadata.append(line);
-					}
+				br = new BufferedReader(new FileReader(file));
+				String line;
+				while ((line = br.readLine()) != null) {
+					ktblMetadata.append(line);
 				}
 			}
-
 		} catch (FileNotFoundException e) {
 			e.printStackTrace();
+		} finally {
+			if (br != null) {
+				br.close();
+			}
 		}
 		play.Logger.debug("ktblMetadata.toString()=" + ktblMetadata.toString());
 		return ktblMetadata.toString();

--- a/app/models/Node.java
+++ b/app/models/Node.java
@@ -325,9 +325,9 @@ public class Node implements java.io.Serializable {
 	/**
 	 * @param metadataFile The absolutepath to the metadatafile
 	 */
-	public void setMetadata2File(String metadataFile) {
-		this.metadata2File = metadataFile;
-	}
+	// public void setMetadata2File(String metadataFile) {
+	// this.metadata2File = metadataFile;
+	// }
 
 	/**
 	 * The metadata file


### PR DESCRIPTION
A new endpoint named updateKtbl for KTBL-Metadata(json) has been implemented in this branch.
This KTBL-Metadata (Json file) will be sent to the new implemented endpoint as a Rest-Api-Call. The endpoint maps the wanted metadata and persists it as a new data stream named KTBL in the Data Layer of the system.

route: PUT /resource/:pid/ktbl