### PR TITLE
Abfangen "indexOutOfBounds", URLEncoding Errors

### DIFF
--- a/app/controllers/AdhocController.java
+++ b/app/controllers/AdhocController.java
@@ -34,9 +34,8 @@ public class AdhocController extends MyController {
 		IRI pred = f.createIRI("http://www.w3.org/2004/02/skos/core#prefLabel");
 		Literal obj = f.createLiteral(RdfUtils.urlDecode(authorname));
 		g.add(f.createStatement(subj, pred, obj));
-		g.add(f.createStatement(subj,
-				f.createIRI(
-						"http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson"),
+		g.add(f.createStatement(subj, f.createIRI(
+				"http://d-nb.info/standards/elementset/gnd#preferredNameForThePerson"),
 				obj));
 		g.add(f.createStatement(subj,
 				f.createIRI("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
@@ -62,29 +61,35 @@ public class AdhocController extends MyController {
 	public static Promise<Result> getAdhocRdf(@PathParam("type") String type,
 			@PathParam("name") String base64EncodedNameWithMod) {
 
-		response().setHeader("Access-Control-Allow-Origin", "*");
-		Collection<Statement> g = new TreeModel();
-		ValueFactory f = RdfUtils.valueFactory;
-		IRI subj = f.createIRI(Globals.protocol + Globals.server + "/adhoc/"
-				+ RdfUtils.urlEncode(type) + "/" + base64EncodedNameWithMod);
-		IRI pred = f.createIRI("http://www.w3.org/2004/02/skos/core#prefLabel");
-		Literal obj =
-				f.createLiteral(helper.MyURLEncoding.decode(base64EncodedNameWithMod));
-		g.add(f.createStatement(subj, pred, obj));
-		return Promise.promise(() -> {
-			String body = "";
-			if (request().accepts("application/rdf+xml")) {
-				response().setHeader("Content-Type",
-						"application/rdf+xml; charset=utf-8");
-				body = RdfUtils.graphToString(g, RDFFormat.RDFXML);
-			} else if (request().accepts("text/plain")) {
-				response().setContentType("text/plain");
-				body = RdfUtils.graphToString(g, RDFFormat.NTRIPLES);
-			} else {
-				response().setContentType("application/json");
-				body = RdfUtils.graphToString(g, RDFFormat.JSONLD);
-			}
-			return ok(body);
-		});
+		try {
+			play.Logger.trace("type=" + type);
+			play.Logger.trace("base64EncodedNameWithMod=" + base64EncodedNameWithMod);
+			response().setHeader("Access-Control-Allow-Origin", "*");
+			Collection<Statement> g = new TreeModel();
+			ValueFactory f = RdfUtils.valueFactory;
+			IRI subj = f.createIRI(Globals.protocol + Globals.server + "/adhoc/"
+					+ RdfUtils.urlEncode(type) + "/" + base64EncodedNameWithMod);
+			IRI pred = f.createIRI("http://www.w3.org/2004/02/skos/core#prefLabel");
+			Literal obj = f
+					.createLiteral(helper.MyURLEncoding.decode(base64EncodedNameWithMod));
+			g.add(f.createStatement(subj, pred, obj));
+			return Promise.promise(() -> {
+				String body = "";
+				if (request().accepts("application/rdf+xml")) {
+					response().setHeader("Content-Type",
+							"application/rdf+xml; charset=utf-8");
+					body = RdfUtils.graphToString(g, RDFFormat.RDFXML);
+				} else if (request().accepts("text/plain")) {
+					response().setContentType("text/plain");
+					body = RdfUtils.graphToString(g, RDFFormat.NTRIPLES);
+				} else {
+					response().setContentType("application/json");
+					body = RdfUtils.graphToString(g, RDFFormat.JSONLD);
+				}
+				return ok(body);
+			});
+		} catch (Exception e) {
+			throw new RuntimeException("AdhocRdf could not be created!");
+		}
 	}
 }

--- a/app/helper/HeritrixWebclient.java
+++ b/app/helper/HeritrixWebclient.java
@@ -34,6 +34,7 @@ class HeritrixWebclient {
 				Play.application().configuration().getString("regal-api.heritrix.pwd");
 
 		Client webclient = null;
+		try {
 		ClientConfig cc = new DefaultClientConfig();
 		// cc.getProperties()
 		// .put(ClientConfig.PROPERTY_FOLLOW_REDIRECTS, true);
@@ -47,6 +48,9 @@ class HeritrixWebclient {
 		// 10sec
 		webclient.setReadTimeout(1000 * 10);
 		return webclient;
+		} catch (Exception e) {
+			throw new RuntimeException("Can not instantiate webclient com.sun.jersey.api.client.Client", e);
+		}
 	}
 
 	private static SSLContext initSsl(ClientConfig cc, String keystorelocation,

--- a/app/helper/JsonMapper.java
+++ b/app/helper/JsonMapper.java
@@ -628,6 +628,7 @@ public class JsonMapper {
 						id = agent.get(ID2).toString();
 					}
 					if (id == null) {
+						play.Logger.trace("agent prefLabel=" + prefLabel);
 						id = Globals.protocol + Globals.server + "/adhoc/author/"
 								+ prefLabel;
 					}
@@ -818,8 +819,6 @@ public class JsonMapper {
 		}
 		return new HashMap<>();
 	}
-
-
 
 	private static Map<String, Object> findContributor(Map<String, Object> m,
 			String authorsId) {

--- a/app/helper/MyEtikettMaker.java
+++ b/app/helper/MyEtikettMaker.java
@@ -125,19 +125,26 @@ public class MyEtikettMaker implements EtikettMakerInterface {
 		try {
 			String result = null;
 			String uri = e.getUri();
+			play.Logger.trace("uri="+uri);
 
 			if (e.getName() != null) {
 				result = e.getName();
+				play.Logger.trace("name="+result);
 			}
 			if (result == null || result.isEmpty()) {
 				String prefix = "";
 				if (uri.startsWith("http://purl.org/dc/elements"))
 					prefix = "dc:";
-				if (uri.contains("#"))
-					return prefix + uri.split("#")[1];
+				if (uri.contains("#")) {
+					String[] uriParts = uri.split("#");
+					if (uriParts.length > 1) 
+						return prefix + uriParts[1];
+				}
 				else if (uri.startsWith("http")) {
 					int i = uri.lastIndexOf("/");
-					return prefix + uri.substring(i + 1);
+					if( (i + 1) < uri.length() ) {
+						return prefix + uri.substring(i + 1);
+					}
 				}
 				result = prefix + uri;
 			}

--- a/app/helper/MyURLEncoding.java
+++ b/app/helper/MyURLEncoding.java
@@ -4,13 +4,23 @@ import java.util.Base64;
 
 public class MyURLEncoding {
 	public static String encode(String encodeMe) {
-		return Base64.getEncoder().encodeToString(encodeMe.getBytes())
-				.replaceAll("/", "-").replaceAll("\\+", "_");
+		play.Logger.trace("encodeMe=" + encodeMe);
+		String base64EncodedName =
+				Base64.getEncoder().encodeToString(encodeMe.getBytes())
+						.replaceAll("/", "-").replaceAll("\\+", "_");
+		play.Logger.trace("base64EncodedName=" + base64EncodedName);
+		return base64EncodedName;
 	}
 
 	public static String decode(String decodeMe) {
+		play.Logger.trace("decodeMe=" + decodeMe);
 		String base64EncodedName =
 				decodeMe.replaceAll("-", "/").replaceAll("_", "+");
+		play.Logger.trace("base64EncodedName=" + base64EncodedName);
+		if( base64EncodedName.endsWith(",") ) {
+			base64EncodedName = base64EncodedName.substring(0,base64EncodedName.length()-1);
+		}
+		play.Logger.trace("base64EncodedName=" + base64EncodedName);
 		return new String(Base64.getDecoder().decode(base64EncodedName));
 	}
 }


### PR DESCRIPTION
Ich fange in diesem PR verschiedene Fehler ab, die bei der Analyse der auf edoweb2 auftretenden Performance-Probleme aufgefallen waren:
- controllers/AdhocController.java getAdhocRdf(): Einfügen eines try-catch-Blockes. Es wurde beobachtet, dass die Methode Fehler schmeißt beim Ausführen von helper.MyURLEncoding.decode(base64EncodedNameWithMod);
- helper/MyEtikettMaker.java getJsonName(): Abfangen von "indexOutOfBounds"-Ausnahmen. 
-  helper/MyURLEncoding.java : Es wurde beobachtet, dass Autorennamen mit "," am Ende nicht base64-dekodiert werden können. Daher entferne ich ein am Ende des Namens stehendes Komma.