### PR TITLE
Edozwo 1159 - updateAll.sh Skript funktioniert nicht

### DIFF
--- a/app/controllers/MyUtils.java
+++ b/app/controllers/MyUtils.java
@@ -177,7 +177,8 @@ public class MyUtils extends MyController {
 
 	@SuppressWarnings("unchecked")
 	private static LocalDate getUpdateTimeStamp(Node node) {
-		SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+		SimpleDateFormat formatter =
+				new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 		// initialise date
 		String lastUpdate = formatter.format(new Date());
 		// try to set date to created (should work in any case)
@@ -203,7 +204,7 @@ public class MyUtils extends MyController {
 					+ e.getMessage());
 		}
 		return LocalDate.parse(lastUpdate,
-				DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+				DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ"));
 	}
 
 	@ApiOperation(produces = "application/json,application/html", nickname = "addObjectTimestamp", value = "addObjectTimestamp", notes = "Add a objectTimestamp", httpMethod = "POST")

--- a/app/controllers/MyUtils.java
+++ b/app/controllers/MyUtils.java
@@ -191,35 +191,15 @@ public class MyUtils extends MyController {
 					+ " couldn't get created timestamp from \"isDescribedBy/created\" "
 					+ e.getMessage());
 		}
-		try {
-			lastUpdate = ((Map<String, Object>) ((Set<Object>) node.getLd2()
-					.get("describedby")).iterator().next()).get("created").toString();
-			play.Logger.debug(
-					"Got last update date from \"describedBy/created\": " + lastUpdate);
-		} catch (Exception e) {
-			play.Logger.warn(node.getPid()
-					+ " couldn't get created timestamp from \"describedBy/created\" "
-					+ e.getMessage());
-		}
 		// try to set date to modified (overrides created)
 		try {
-			lastUpdate = ((Map<String, Object>) ((Set<Object>) node.getLd2()
-					.get("isDescribedby")).iterator().next()).get("modified").toString();
+			lastUpdate = ((Map<String, Object>) node.getLd2().get("isDescribedby"))
+					.get("modified").toString();
 			play.Logger.debug("Got last update date from \"isDescribedBy/modified\": "
 					+ lastUpdate);
 		} catch (Exception e) {
 			play.Logger.info(node.getPid()
 					+ " couldn't get modified timestamp from \"isDescribedBy/modified\" "
-					+ e.getMessage());
-		}
-		try {
-			lastUpdate = ((Map<String, Object>) ((Set<Object>) node.getLd2()
-					.get("describedby")).iterator().next()).get("modified").toString();
-			play.Logger.debug(
-					"Got last update date from \"describedBy/modified\": " + lastUpdate);
-		} catch (Exception e) {
-			play.Logger.info(node.getPid()
-					+ " couldn't get modified timestamp from \"describedBy/modified\" "
 					+ e.getMessage());
 		}
 		return LocalDate.parse(lastUpdate, DateTimeFormatter.ofPattern("yyyyMMdd"));

--- a/app/controllers/MyUtils.java
+++ b/app/controllers/MyUtils.java
@@ -175,14 +175,15 @@ public class MyUtils extends MyController {
 		});
 	}
 
+	@SuppressWarnings("unchecked")
 	private static LocalDate getUpdateTimeStamp(Node node) {
 		SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMdd");
 		// initialise date
 		String lastUpdate = formatter.format(new Date());
 		// try to set date to created (should work in any case)
 		try {
-			lastUpdate = ((Map<String, Object>) ((Set<Object>) node.getLd2()
-					.get("isDescribedby")).iterator().next()).get("created").toString();
+			lastUpdate = ((Map<String, Object>) node.getLd2().get("isDescribedBy"))
+					.get("created").toString();
 			play.Logger.debug(
 					"Got last update date from \"isDescribedBy/created\": " + lastUpdate);
 		} catch (Exception e) {

--- a/app/controllers/MyUtils.java
+++ b/app/controllers/MyUtils.java
@@ -177,7 +177,7 @@ public class MyUtils extends MyController {
 
 	@SuppressWarnings("unchecked")
 	private static LocalDate getUpdateTimeStamp(Node node) {
-		SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMdd");
+		SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
 		// initialise date
 		String lastUpdate = formatter.format(new Date());
 		// try to set date to created (should work in any case)
@@ -202,7 +202,8 @@ public class MyUtils extends MyController {
 					+ " couldn't get modified timestamp from \"isDescribedBy/modified\" "
 					+ e.getMessage());
 		}
-		return LocalDate.parse(lastUpdate, DateTimeFormatter.ofPattern("yyyyMMdd"));
+		return LocalDate.parse(lastUpdate,
+				DateTimeFormatter.ofPattern("yyyy-MM-dd"));
 	}
 
 	@ApiOperation(produces = "application/json,application/html", nickname = "addObjectTimestamp", value = "addObjectTimestamp", notes = "Add a objectTimestamp", httpMethod = "POST")

--- a/app/controllers/MyUtils.java
+++ b/app/controllers/MyUtils.java
@@ -193,7 +193,7 @@ public class MyUtils extends MyController {
 		}
 		// try to set date to modified (overrides created)
 		try {
-			lastUpdate = ((Map<String, Object>) node.getLd2().get("isDescribedby"))
+			lastUpdate = ((Map<String, Object>) node.getLd2().get("isDescribedBy"))
 					.get("modified").toString();
 			play.Logger.debug("Got last update date from \"isDescribedBy/modified\": "
 					+ lastUpdate);

--- a/app/helper/JsonMapper.java
+++ b/app/helper/JsonMapper.java
@@ -941,7 +941,12 @@ public class JsonMapper {
 		if (node.getLastModifiedBy() != null)
 			aboutMap.put(lastModifiedBy, node.getLastModifiedBy());
 
-		aboutMap.put(modified, node.getLastModified());
+		try {
+			aboutMap.put(modified, new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+					.format(node.getLastModified()));
+		} catch (Exception e) {
+			aboutMap.put(modified, node.getLastModified());
+		}
 		if (node.getObjectTimestamp() != null) {
 			aboutMap.put(objectTimestamp, node.getObjectTimestamp());
 		} else {

--- a/app/helper/JsonMapper.java
+++ b/app/helper/JsonMapper.java
@@ -421,7 +421,6 @@ public class JsonMapper {
 	}
 
 	private void postProcessLinkFields(String key, Map<String, Object> rdf) {
-		play.Logger.debug("key=" + key);
 		Object myObj = rdf.get(key);
 		if (myObj instanceof java.util.HashSet) {
 			HashSet<Map<String, String>> all =

--- a/app/helper/JsonMapper.java
+++ b/app/helper/JsonMapper.java
@@ -991,7 +991,6 @@ public class JsonMapper {
 		ObjectMapper mapper = new ObjectMapper();
 
 		String issued = getPublicationMap(mapper.convertValue(rdf, JsonNode.class));
-		play.Logger.debug("getPublicationMap(), issued=" + issued);
 
 		if (issued != null) {
 			rdf.put("issued", issued);


### PR DESCRIPTION
Dieser PR behebt die Probleme mit dem updateAll.sh - Skript.
Das Skript hatte zuletzt nicht mehr funktioniert.
Probleme konnten identifiziert und behoben werden:
  - Datenformatänderungen bei lobid parallel zur Alma-Umstellung:
 - isDescribedBy ist ein Objekt, keine Liste
 - Werte "created" und "modified" in isDescribedBy werden im DateTime-Format yyyy-MM-DD-T-hh-mm-SSSZ abgespeichert. War bisher: yyyMMDD.
 - describedby beschreibt etwas anderes als "isDescribedBy" !!

Ausgerollt und erfolgreich getestet auf edoweb-test2.
Ausgerollt auf edoweb.