### PR TITLE
Tos 1178

### DIFF
--- a/app/actions/Create.java
+++ b/app/actions/Create.java
@@ -726,7 +726,7 @@ public class Create extends RegalAction {
 			ApplicationLogger
 					.debug("INFO Webpage mit PID " + node.getPid() + " erzeugt.");
 
-			new Modify().updateLobidifyAndEnrichMetadata(node, "<" + node.getPid()
+			new Modify().updateLobidify2AndEnrichMetadata(node, "<" + node.getPid()
 					+ "> <http://purl.org/dc/terms/title> \"" + title + "\" .");
 
 			// node = updateResource(node); braucht man das ?

--- a/app/actions/Create.java
+++ b/app/actions/Create.java
@@ -701,4 +701,47 @@ public class Create extends RegalAction {
 		}
 	}
 
+	/**
+	 * Diese Methode legt einen Node vom contentType "webpage" an. Der Node kann
+	 * dabei mit einem vorläufigen Titel (in den Metadaten) sowie mit einer
+	 * Konfigurationsdatei für das Webgathering (Gatherconf) mit URL und
+	 * Intervallangabe versehen werden.
+	 * 
+	 * @author Ingolf Kuss 21.01.2025 | Neuanlage für TOS-1178
+	 *
+	 * @param namespace Der Namensraum, in der die PID angelegt werden soll
+	 * @param url Die URL, die gesammelt werdn soll
+	 * @param title Der vorläufige Titel der Webpage
+	 * @param intervall Das Sammelintervall
+	 * @param object ToScienceObject für die neue Webpage
+	 * @return Der modifizierte Node vom contentType webpage
+	 */
+	public Node createWebpage(String namespace, String url, String title,
+			String intervall, ToScienceObject object) {
+		try {
+			ApplicationLogger.debug("Create Webpage for url: " + url + ", title: "
+					+ title + ", intervall: " + intervall);
+
+			Node node = createResource(namespace, object);
+			ApplicationLogger
+					.debug("INFO Webpage mit PID " + node.getPid() + " erzeugt.");
+
+			new Modify().updateLobidifyAndEnrichMetadata(node, "<" + node.getPid()
+					+ "> <http://purl.org/dc/terms/title> \"" + title + "\" .");
+
+			// node = updateResource(node); braucht man das ?
+
+			ApplicationLogger.info("Successfully created webpage " + node.getPid()
+					+ "  with title " + title + " !");
+			return node;
+
+		} catch (Exception e) {
+			ApplicationLogger.error(
+					"Creation of webpage in namespace {} for URL {} has failed !\n\tReason: {}",
+					namespace, url, e.getMessage());
+			ApplicationLogger.debug("", e);
+			throw new RuntimeException(e);
+		}
+	}
+
 } /* END of Class Create */

--- a/app/controllers/Resource.java
+++ b/app/controllers/Resource.java
@@ -1398,8 +1398,6 @@ public class Resource extends MyController {
 			@QueryParam("interval") String intervall) {
 		return new CreateAction().call(userId -> {
 			ToScienceObject object = getRegalObject(request().body().asJson());
-			object.setContentType("webpage");
-			object.setAccessScheme("restricted");
 			Node result =
 					create.createWebpage(namespace, url, title, intervall, object);
 			response().setHeader("Location", read.getHttpUriOfResource(result));

--- a/app/controllers/Resource.java
+++ b/app/controllers/Resource.java
@@ -1383,6 +1383,30 @@ public class Resource extends MyController {
 		});
 	}
 
+	/**
+	 * Mit diesem Endpoint kann man eine Webpage mitsamt URL und vorläufigem Titel
+	 * anlegen.
+	 * 
+	 * @author Ingolf Kuss, hbz
+	 */
+	@ApiOperation(produces = "application/json", nickname = "createWebpage", value = "createNewWebpage", notes = "Creates a Webpage on a new position", response = Message.class, httpMethod = "POST")
+	@ApiImplicitParams({
+			@ApiImplicitParam(value = "New Object", required = true, dataType = "Node", paramType = "body") })
+	public static Promise<Result> createWebpage(
+			@PathParam("namespace") String namespace, @QueryParam("url") String url,
+			@QueryParam("title") String title,
+			@QueryParam("interval") String intervall) {
+		return new CreateAction().call(userId -> {
+			ToScienceObject object = getRegalObject(request().body().asJson());
+			object.setContentType("webpage");
+			object.setAccessScheme("restricted");
+			Node result =
+					create.createWebpage(namespace, url, title, intervall, object);
+			response().setHeader("Location", read.getHttpUriOfResource(result));
+			return getJsonResult(result);
+		});
+	}
+
 	@ApiOperation(produces = "application/json", nickname = "linkVersion", value = "linkVersion", response = Result.class, httpMethod = "POST")
 	public static Promise<Result> linkVersion(@PathParam("pid") String pid) {
 		return new ModifyAction().call(pid, userId -> {

--- a/conf.tmpl/routes
+++ b/conf.tmpl/routes
@@ -85,7 +85,7 @@ POST /resource/:pid/postVersion  	controllers.Resource.postVersion(pid,versionPi
 POST /resource/:pid/linkVersion  	controllers.Resource.linkVersion(pid)
 POST /resource/:pid/publishVersion  controllers.Resource.publishWebpageVersion(pid,accessScheme?="public")
 POST /resource/:pid/postResearchData	controllers.Resource.createResearchData(pid,collectionUrl?="data",subPath?="",filename?="",resourcePid?="")
-POST /resource/:namespace/createWebpage		controllers.Resource.createWebpage(url?="",title?="",interval?="")
+POST /resource/:namespace/createWebpage		controllers.Resource.createWebpage(namespace,url?="",title?="",interval?="")
 POST /resource/:namespace			controllers.Resource.createResource(namespace)
 POST /resource/:pid/doi             controllers.Resource.addDoi(pid)
 POST /resource/:pid/doi/update      controllers.Resource.updateDoi(pid)

--- a/conf.tmpl/routes
+++ b/conf.tmpl/routes
@@ -85,6 +85,7 @@ POST /resource/:pid/postVersion  	controllers.Resource.postVersion(pid,versionPi
 POST /resource/:pid/linkVersion  	controllers.Resource.linkVersion(pid)
 POST /resource/:pid/publishVersion  controllers.Resource.publishWebpageVersion(pid,accessScheme?="public")
 POST /resource/:pid/postResearchData	controllers.Resource.createResearchData(pid,collectionUrl?="data",subPath?="",filename?="",resourcePid?="")
+POST /resource/:namespace/createWebpage		controllers.Resource.createWebpage(url?="",title?="",interval?="")
 POST /resource/:namespace			controllers.Resource.createResource(namespace)
 POST /resource/:pid/doi             controllers.Resource.addDoi(pid)
 POST /resource/:pid/doi/update      controllers.Resource.updateDoi(pid)


### PR DESCRIPTION
Ein neuer Endpoint createWebpage zur Anlage einer Webpage mit URL, vorläufigem Titel und Crawl-Intervall.
Zur automatisierten Anlage von Webpages anhand einer CSV-Datei (s. dazugehörige, neue Skripte in to.science.scripts: ks.createWebarchivEntries.sh und createWebpage.sh.
Für TOS-1178 und TOS-1177: 800er-Listen der NRW Landesbibliotheken.