### PR TITLE
Erkenne exitState == 7 von wpull als erfolgreich

### DIFF
--- a/app/helper/WpullThread.java
+++ b/app/helper/WpullThread.java
@@ -248,7 +248,9 @@ public class WpullThread extends Thread {
 			WebgatherLogger.info("Webcrawl for " + conf.getName()
 					+ " exited with exitState " + exitState);
 			proc.destroy();
-			if (exitState == 0 || exitState == 4 || exitState == 8) {
+			if (exitState == 0 || exitState == 4 || exitState == 7 || exitState == 8) {
+				/* der Beobachtung zufolge wird bei exitState == 7 das WARC ge-moved */
+				/* daher legen wir ab jetzt auch einen Webschnitt an. IK20250205 für TOS-1182 und TOS-1224 */
 				new Create().createWebpageVersion(node, conf, outDir, localpath);
 				WebgatherLogger
 						.info("WebpageVersion für " + conf.getName() + "wurde angelegt.");


### PR DESCRIPTION
  - erwiesernermaßen wird bei diesem ExitState ein "move" des WARC nach /data/wpull-data/ ausgeführt und das WARC von pywb indexiert. Daher sollte dann auch ein Webschnitt angelegt werden. Das passiert aber nur, wenn die Java-Logik diesen exitState als "erfolgreiche" behandelt. Bisher war das nicht der Fall (nur bei 0,4,8).