### PR TITLE
Tosdev 5 - Sekundengenaue Crawls

### DIFF
--- a/app/actions/Create.java
+++ b/app/actions/Create.java
@@ -303,11 +303,31 @@ public class Create extends RegalAction {
 	 */
 	public Node createWebpageVersion(Node n, Gatherconf conf, File outDir,
 			String localpath) {
-		String label = new SimpleDateFormat("yyyy-MM-dd").format(new Date());
-		String owDatestamp = new SimpleDateFormat("yyyyMMdd").format(new Date());
-		String versionPid = null;
-		return createWebpageVersion(n, conf, outDir, localpath, versionPid, label,
-				owDatestamp);
+		try {
+			/* Das Label, das auf dem Link "Zum Webschnitt" angezeigt werden soll */
+			/*
+			 * get basename of outDir = the timestamp for when the crawl has started
+			 */
+			String datetime = outDir.getName();
+			SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMddHHmmss");
+			Date startdate = sdf.parse(datetime);
+			String label =
+					new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(startdate);
+			/*
+			 * Der Zeitstempel, mit dem die Open Wayback (oder Python Wayback)
+			 * einsteigen soll
+			 */
+			String owDatestamp = datetime;
+			String versionPid = null;
+			return createWebpageVersion(n, conf, outDir, localpath, versionPid, label,
+					owDatestamp);
+		} catch (Exception e) {
+			WebgatherLogger.warn("Anlage einer Webpage-Version zu PID,URL "
+					+ n.getPid() + "," + conf.getUrl()
+					+ " ist fehlgeschlagen !\n\tGrund: " + e.getMessage());
+			WebgatherLogger.debug("", e);
+			throw new RuntimeException(e);
+		}
 	}
 
 	/**
@@ -500,9 +520,11 @@ public class Create extends RegalAction {
 			String localpath = Globals.heritrixData + "/wpull-data" + "/"
 					+ conf.getName() + "/" + timestamp + "/" + filename;
 			ApplicationLogger.debug("URI-Path to WARC " + localpath);
-			String label = timestamp.substring(0, 4) + "-" + timestamp.substring(4, 6)
-					+ "-" + timestamp.substring(6, 8);
-			String owDatestamp = timestamp.substring(0, 8);
+			SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMddHHmmss");
+			Date startdate = sdf.parse(timestamp);
+			String label =
+					new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(startdate);
+			String owDatestamp = timestamp;
 			return createWebpageVersion(n, conf, outDir, localpath, versionPid, label,
 					owDatestamp);
 

--- a/app/actions/Create.java
+++ b/app/actions/Create.java
@@ -21,6 +21,9 @@ import static archive.fedora.Vocabulary.TYPE_OBJECT;
 import java.io.File;
 import java.math.BigInteger;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.List;
 // import javax.activation.MimetypesFileTypeMap;
@@ -309,15 +312,18 @@ public class Create extends RegalAction {
 			 * get basename of outDir = the timestamp for when the crawl has started
 			 */
 			String datetime = outDir.getName();
-			SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMddHHmmss");
-			Date startdate = sdf.parse(datetime);
+			DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+			LocalDate startdate = LocalDate.parse(datetime, dtf);
 			String label =
 					new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(startdate);
 			/*
 			 * Der Zeitstempel, mit dem die Open Wayback (oder Python Wayback)
 			 * einsteigen soll
 			 */
-			String owDatestamp = datetime;
+			Date startdateUTC =
+					Date.from(startdate.atStartOfDay().toInstant(ZoneOffset.UTC));
+			String owDatestamp =
+					new SimpleDateFormat("yyyyMMddHHmmss").format(startdateUTC);
 			String versionPid = null;
 			return createWebpageVersion(n, conf, outDir, localpath, versionPid, label,
 					owDatestamp);
@@ -520,11 +526,20 @@ public class Create extends RegalAction {
 			String localpath = Globals.heritrixData + "/wpull-data" + "/"
 					+ conf.getName() + "/" + timestamp + "/" + filename;
 			ApplicationLogger.debug("URI-Path to WARC " + localpath);
-			SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMddHHmmss");
-			Date startdate = sdf.parse(timestamp);
+
+			DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+			LocalDate startdate = LocalDate.parse(timestamp, dtf);
 			String label =
 					new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(startdate);
-			String owDatestamp = timestamp;
+			/*
+			 * Der Zeitstempel, mit dem die Open Wayback (oder Python Wayback)
+			 * einsteigen soll
+			 */
+			Date startdateUTC =
+					Date.from(startdate.atStartOfDay().toInstant(ZoneOffset.UTC));
+			String owDatestamp =
+					new SimpleDateFormat("yyyyMMddHHmmss").format(startdateUTC);
+
 			return createWebpageVersion(n, conf, outDir, localpath, versionPid, label,
 					owDatestamp);
 

--- a/app/actions/Create.java
+++ b/app/actions/Create.java
@@ -22,7 +22,10 @@ import java.io.File;
 import java.math.BigInteger;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.List;
@@ -324,9 +327,9 @@ public class Create extends RegalAction {
 			 * einsteigen soll. Es ist standardmäßig in UTC anzugeben.
 			 */
 			DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
-			LocalDate startdateLocal = LocalDate.parse(datetime, dtf);
-			Date startdateUTC =
-					Date.from(startdateLocal.atStartOfDay().toInstant(ZoneOffset.UTC));
+			LocalDateTime startdateLocal = LocalDateTime.parse(datetime, dtf);
+			ZonedDateTime startdateUTC = startdateLocal.atZone(ZoneId.systemDefault())
+					.withZoneSameInstant(ZoneOffset.UTC);
 			String owDatestamp =
 					new SimpleDateFormat("yyyyMMddHHmmss").format(startdateUTC);
 			return createWebpageVersion(n, conf, outDir, localpath, versionPid, label,

--- a/app/actions/Create.java
+++ b/app/actions/Create.java
@@ -302,29 +302,33 @@ public class Create extends RegalAction {
 	 *          Version des neuen Webschnitts liegt.
 	 * @param localpath Die URI, unter der die Webpage-Version lokal gespeichert
 	 *          wird
+	 * @param versionPid Die PID für die WebpageVersion, oder null. Bei null wird
+	 *          PID vom System vergeben.
 	 * @return Der Knoten der neuen Webpage-Version
 	 */
 	public Node createWebpageVersion(Node n, Gatherconf conf, File outDir,
-			String localpath) {
+			String localpath, String versionPid) {
 		try {
 			/* Das Label, das auf dem Link "Zum Webschnitt" angezeigt werden soll */
 			/*
 			 * get basename of outDir = the timestamp for when the crawl has started
 			 */
 			String datetime = outDir.getName();
-			DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
-			LocalDate startdate = LocalDate.parse(datetime, dtf);
+			SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMddHHmmss");
+			Date startdate = sdf.parse(datetime);
 			String label =
 					new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(startdate);
+			WebgatherLogger.info("Webschnitt Label=" + label);
 			/*
 			 * Der Zeitstempel, mit dem die Open Wayback (oder Python Wayback)
-			 * einsteigen soll
+			 * einsteigen soll. Es ist standardmäßig in UTC anzugeben.
 			 */
+			DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+			LocalDate startdateLocal = LocalDate.parse(datetime, dtf);
 			Date startdateUTC =
-					Date.from(startdate.atStartOfDay().toInstant(ZoneOffset.UTC));
+					Date.from(startdateLocal.atStartOfDay().toInstant(ZoneOffset.UTC));
 			String owDatestamp =
 					new SimpleDateFormat("yyyyMMddHHmmss").format(startdateUTC);
-			String versionPid = null;
 			return createWebpageVersion(n, conf, outDir, localpath, versionPid, label,
 					owDatestamp);
 		} catch (Exception e) {
@@ -527,22 +531,7 @@ public class Create extends RegalAction {
 					+ conf.getName() + "/" + timestamp + "/" + filename;
 			ApplicationLogger.debug("URI-Path to WARC " + localpath);
 
-			DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
-			LocalDate startdate = LocalDate.parse(timestamp, dtf);
-			String label =
-					new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(startdate);
-			/*
-			 * Der Zeitstempel, mit dem die Open Wayback (oder Python Wayback)
-			 * einsteigen soll
-			 */
-			Date startdateUTC =
-					Date.from(startdate.atStartOfDay().toInstant(ZoneOffset.UTC));
-			String owDatestamp =
-					new SimpleDateFormat("yyyyMMddHHmmss").format(startdateUTC);
-
-			return createWebpageVersion(n, conf, outDir, localpath, versionPid, label,
-					owDatestamp);
-
+			return createWebpageVersion(n, conf, outDir, localpath, versionPid);
 		} catch (Exception e) {
 			ApplicationLogger.error(
 					"Anlegen der WebsiteVersion {} zu Webpage {} ist fehlgeschlagen !",

--- a/app/actions/Create.java
+++ b/app/actions/Create.java
@@ -331,7 +331,7 @@ public class Create extends RegalAction {
 			ZonedDateTime startdateUTC = startdateLocal.atZone(ZoneId.systemDefault())
 					.withZoneSameInstant(ZoneOffset.UTC);
 			String owDatestamp =
-					new SimpleDateFormat("yyyyMMddHHmmss").format(startdateUTC);
+					DateTimeFormatter.ofPattern("yyyyMMddHHmmss").format(startdateUTC);
 			return createWebpageVersion(n, conf, outDir, localpath, versionPid, label,
 					owDatestamp);
 		} catch (Exception e) {

--- a/app/helper/WebgatherUtils.java
+++ b/app/helper/WebgatherUtils.java
@@ -168,7 +168,9 @@ public class WebgatherUtils {
 
 				localpath = Globals.heritrixData + "/heritrix-data" + "/" + uriPath;
 				WebgatherLogger.debug("Path to WARC " + localpath);
-				new Create().createWebpageVersion(node, conf, crawlDir, localpath);
+				String versionPid = null;
+				new Create().createWebpageVersion(node, conf, crawlDir, localpath,
+						versionPid);
 			} else if (conf.getCrawlerSelection()
 					.equals(Gatherconf.CrawlerSelection.wpull)) {
 				WpullCrawl wpullCrawl = new WpullCrawl(node, conf);

--- a/app/helper/WpullCrawl.java
+++ b/app/helper/WpullCrawl.java
@@ -158,7 +158,7 @@ public class WpullCrawl {
 					date + new SimpleDateFormat("HHmmss").format(new java.util.Date());
 			this.crawlDir = new File(jobDir + "/" + conf.getName() + "/" + datetime);
 			this.resultDir = new File(outDir + "/" + conf.getName() + "/" + datetime);
-			this.warcFilename = "WEB-" + host + "-" + date;
+			this.warcFilename = "WEB-" + host + "-" + datetime;
 			/*
 			 * Die URI localpath wird von Fedora benötigt, um ein Objekt anlegen zu
 			 * können. Ohne "localpath" wird im Frontend kein Link zur Wayback

--- a/app/helper/WpullThread.java
+++ b/app/helper/WpullThread.java
@@ -261,7 +261,9 @@ public class WpullThread extends Thread {
 				 * daher legen wir ab jetzt auch einen Webschnitt an. IK20250205 für
 				 * TOS-1182 und TOS-1224
 				 */
-				new Create().createWebpageVersion(node, conf, outDir, localpath);
+				String versionPid = null;
+				new Create().createWebpageVersion(node, conf, outDir, localpath,
+						versionPid);
 				WebgatherLogger
 						.info("WebpageVersion für " + conf.getName() + "wurde angelegt.");
 				return;

--- a/test/HeritrixTest.java
+++ b/test/HeritrixTest.java
@@ -49,8 +49,9 @@ public class HeritrixTest {
 				String uriPath = Globals.heritrix.getUriPath(warcPath);
 				String localpath =
 						Globals.heritrixData + "/heritrix-data" + "/" + uriPath;
-				Node webpageVersion =
-						create.createWebpageVersion(webpage, conf, crawlDir, localpath);
+				String versionPid = null;
+				Node webpageVersion = create.createWebpageVersion(webpage, conf,
+						crawlDir, localpath, versionPid);
 			}
 		});
 	}


### PR DESCRIPTION
Mehrere Crawls am gleichen Tag für die gleiche Domain ermöglichen

für verschiedene Anwendungsfälle:

    - Manchmal unterscheiden sich Titelaufnahmen für Websites bei der URL nur im Pfad, nicht in der Domain
    - verschiedene Einstiegspunkt (Pfade) zum Crawlen derselben Domain ermöglichen
    - für den Testbetrieb. Man will meherere Versuche am selben Tag machen, aber nicht immer soll nur der letzte Versuch erhalten bleiben. Z.Zt. überschreibt die zuletzt gecrawlte Site alle anderen der gleichen Domain vom gleichen Tag.

Lösungsansatz über Zeitstempel im Namen des WARC-Archives und dann auch im Link "Zum Webschnitt".
