### PR TITLE
Tos 1103 - inkrementelles Crawling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ scripts/variables.conf
 *.HIST
 *~
 *.class
+/bin/

--- a/app/actions/Create.java
+++ b/app/actions/Create.java
@@ -68,8 +68,6 @@ public class Create extends RegalAction {
 	private static final Logger.ALogger WebgatherLogger =
 			Logger.of("webgatherer");
 	private static final BigInteger bigInt1024 = new BigInteger("1024");
-	private final static String wpullOutBaseDir =
-			Play.application().configuration().getString("regal-api.wpull.outDir");
 
 	@SuppressWarnings({ "javadoc", "serial" })
 	public class WebgathererTooBusyException extends HttpArchiveException {
@@ -400,7 +398,8 @@ public class Create extends RegalAction {
 			File cdxFileNew =
 					new File(outDir.getAbsolutePath() + "/" + warcFilename + ".cdx");
 			if (cdxFileNew.exists()) {
-				File cdxFileSave = new File(wpullOutBaseDir + "/" + conf.getName()
+				File cdxFileSave = new File(Play.application().configuration()
+						.getString("regal-api.wpull.outDir") + "/" + conf.getName()
 						+ "/WEB-" + WebgatherUtils.getDomain(conf.getUrl()) + ".cdx");
 				FileUtils.copyFile(cdxFileNew, cdxFileSave);
 				WebgatherLogger.debug(

--- a/app/controllers/Resource.java
+++ b/app/controllers/Resource.java
@@ -1282,7 +1282,7 @@ public class Resource extends MyController {
 					conf = MyController.mapper.readValue(o.toString(), Gatherconf.class);
 					// hier die neue conf auch im JobDir von Heritrix ablegen
 					conf.setName(pid);
-					conf.setRobotsPolicy(RobotsPolicy.ignore);
+					// conf.setRobotsPolicy(RobotsPolicy.ignore);
 					play.Logger.debug("conf.toString=" + conf.toString());
 					String result = modify.updateConf(node, conf.toString());
 					// Neue urlHist anlegen, falls es noch keine gibt (nur dann)

--- a/app/helper/WebgatherUtils.java
+++ b/app/helper/WebgatherUtils.java
@@ -170,10 +170,14 @@ public class WebgatherUtils {
 				crawlDir = Globals.heritrix.getCurrentCrawlDir(conf.getName());
 				String warcPath = Globals.heritrix.findLatestWarc(crawlDir);
 				String uriPath = Globals.heritrix.getUriPath(warcPath);
+				String warcFilename = new File(warcPath).getName();
+				WebgatherLogger.debug("WARC file name: " + warcFilename);
 
 				localpath = Globals.heritrixData + "/heritrix-data" + "/" + uriPath;
 				WebgatherLogger.debug("Path to WARC " + localpath);
-				new Create().createWebpageVersion(node, conf, crawlDir, localpath);
+
+				new Create().createWebpageVersion(node, conf, warcFilename, crawlDir,
+						localpath);
 			} else if (conf.getCrawlerSelection()
 					.equals(Gatherconf.CrawlerSelection.wpull)) {
 				WpullCrawl wpullCrawl = new WpullCrawl(node, conf);
@@ -245,6 +249,19 @@ public class WebgatherUtils {
 			fileName = "/tmp/lastlyCrawledWebpageId";
 		}
 		return fileName;
+	}
+
+	/**
+	 * Diese Methode ermittelt aus einer URL die Domain.
+	 * 
+	 * @author Ingolf Kuss
+	 * @date 2025-03-13
+	 * @param url eine URL
+	 * @return die Domain der URL
+	 */
+	public static String getDomain(String url) {
+		return url.replaceAll("^http://", "").replaceAll("^https://", "")
+				.replaceAll("/.*$", "");
 	}
 
 }

--- a/app/helper/WpullCrawl.java
+++ b/app/helper/WpullCrawl.java
@@ -175,8 +175,7 @@ public class WpullCrawl {
 			WebgatherLogger.debug("URL=" + conf.getUrl());
 			this.urlAscii = WebgatherUtils.convertUnicodeURLToAscii(conf.getUrl());
 			WebgatherLogger.debug("urlAscii=" + urlAscii);
-			this.host = urlAscii.replaceAll("^http://", "")
-					.replaceAll("^https://", "").replaceAll("/.*$", "");
+			this.host = WebgatherUtils.getDomain(urlAscii);
 			WebgatherLogger.debug("host=" + host);
 			this.date = new SimpleDateFormat("yyyyMMdd").format(new java.util.Date());
 			this.datetime =
@@ -270,10 +269,6 @@ public class WpullCrawl {
 				executeCommand = executeCommand.concat(" " + cdxFileNew.getName());
 			}
 			String[] execArr = executeCommand.split(" ");
-			// unmask spaces in exec command
-			for (int i = 0; i < execArr.length; i++) {
-				execArr[i] = execArr[i].replaceAll("%20", " ");
-			}
 			executeCommand = executeCommand.replaceAll("%20", " ");
 			WebgatherLogger.info("Executing command " + executeCommand);
 			WebgatherLogger
@@ -410,6 +405,8 @@ public class WpullCrawl {
 		// auskommentiert 27.08.2020 für EDOZWO-1026
 		// sb.append(" --warc-tempdir=" + tempJobDir)
 		sb.append(" --warc-move=" + resultDir);
+		sb.append(" --warc-cdx");
+		sb.append(" --warc-dedup=" + warcFilename + ".cdx");
 		play.Logger.debug("Built Crawl command: " + sb.toString());
 		return sb.toString();
 	}

--- a/app/helper/WpullCrawl.java
+++ b/app/helper/WpullCrawl.java
@@ -44,6 +44,8 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.io.FileUtils;
+
 /**
  * a class to implement a wpull crawl
  * 
@@ -64,6 +66,8 @@ public class WpullCrawl {
 	private String datetime = null;
 	private File crawlDir = null;
 	private File resultDir = null;
+	private File cdxFile = null;
+	private File cdxFileNew = null;
 	private String localpath = null;
 	private String host = null;
 	private String warcFilename = null;
@@ -117,6 +121,27 @@ public class WpullCrawl {
 	}
 
 	/**
+	 * Die Methode, um die CDX-Datei auszulesen
+	 * 
+	 * @return cdxFile ist eine Datei, die wpull dem Parameter --warc-dedup
+	 *         übergibt. Die Datei enthält eine Liste bereits eingesammelter URLs.
+	 */
+	public File getCdxFile() {
+		return cdxFile;
+	}
+
+	/**
+	 * Die Methode, um die neue CDX-Datei auszulesen
+	 * 
+	 * @return cdxFileNew ist eine CDX-Datei, die wpull beim nächsten Crawl neu
+	 *         schreibt. Als Anfangswert wird die bisherige cdx-Datei, cdxFile
+	 *         (="old"), hier hinein kopiert.
+	 */
+	public File getCdxFileNew() {
+		return cdxFileNew;
+	}
+
+	/**
 	 * Die Methode, um localPath auszulesen
 	 * 
 	 * @return localPath is ein Parameter, den Fedora benötigt. Es ist eine URL
@@ -158,6 +183,8 @@ public class WpullCrawl {
 					date + new SimpleDateFormat("HHmmss").format(new java.util.Date());
 			this.crawlDir = new File(jobDir + "/" + conf.getName() + "/" + datetime);
 			this.resultDir = new File(outDir + "/" + conf.getName() + "/" + datetime);
+			this.cdxFile =
+					new File(outDir + "/" + conf.getName() + "/WEB-" + host + ".cdx");
 			this.warcFilename = "WEB-" + host + "-" + date;
 			/*
 			 * Die URI localpath wird von Fedora benötigt, um ein Objekt anlegen zu
@@ -173,7 +200,7 @@ public class WpullCrawl {
 	}
 
 	/**
-	 * creates a new wpull crawler job
+	 * Erzeugt einen neuen Wpull-Crawler-Job
 	 */
 	public void createJob() {
 		WebgatherLogger.debug("Create new job " + conf.getName());
@@ -192,6 +219,26 @@ public class WpullCrawl {
 				WebgatherLogger.debug("Create Output Directory " + outDir + "/"
 						+ conf.getName() + "/" + datetime);
 				resultDir.mkdirs();
+			}
+			/**
+			 * Dieser Codeblock wird für das inkrementelle Crawling benötigt. Es wird
+			 * geschaut, ob eine CDX-Datei für diese Webpage existiert. Eine CDX-Datei
+			 * enthält eine Liste bereits gesammelter URLs für diese Webpage. Falls
+			 * eine CDX-Datei existiert, wird sie in das Arbeitsverzeichnis jobDir
+			 * kopiert und entsprechend so umbenannt, dass der neue Crawl sie weiter
+			 * schreiben wird.
+			 * 
+			 * @author Ingolf Kuss
+			 * @date 2025-03-12
+			 */
+			if (cdxFile.exists()) {
+				WebgatherLogger
+						.debug("CDX-Datei gefunden: " + cdxFile.getAbsolutePath());
+				this.cdxFileNew = new File(
+						this.crawlDir.getAbsolutePath() + "/" + this.warcFilename + ".cdx");
+				FileUtils.copyFile(cdxFile, cdxFileNew);
+				WebgatherLogger
+						.debug("Neue CDX-Datei angelegt: " + cdxFileNew.getAbsolutePath());
 			}
 		} catch (Exception e) {
 			msg = "Cannot create jobDir in " + jobDir + "/" + conf.getName();
@@ -214,9 +261,13 @@ public class WpullCrawl {
 			AgentIdSelection agentId = conf.getAgentIdSelection();
 			executeCommand =
 					executeCommand.concat(" " + Gatherconf.agentTable.get(agentId));
+			executeCommand = executeCommand.concat(" Cookie:%20");
 			if (conf.getCookie() != null && !conf.getCookie().isEmpty()) {
-				executeCommand = executeCommand
-						.concat(" " + conf.getCookie().replaceAll(" ", "%20"));
+				executeCommand =
+						executeCommand.concat(conf.getCookie().replaceAll(" ", "%20"));
+			}
+			if (cdxFileNew != null) {
+				executeCommand = executeCommand.concat(" " + cdxFileNew.getName());
 			}
 			String[] execArr = executeCommand.split(" ");
 			// unmask spaces in exec command

--- a/app/helper/WpullCrawl.java
+++ b/app/helper/WpullCrawl.java
@@ -261,7 +261,7 @@ public class WpullCrawl {
 			AgentIdSelection agentId = conf.getAgentIdSelection();
 			executeCommand =
 					executeCommand.concat(" " + Gatherconf.agentTable.get(agentId));
-			executeCommand = executeCommand.concat(" Cookie:%20");
+			executeCommand = executeCommand.concat(" Cookie:");
 			if (conf.getCookie() != null && !conf.getCookie().isEmpty()) {
 				executeCommand =
 						executeCommand.concat(conf.getCookie().replaceAll(" ", "%20"));

--- a/app/helper/WpullThread.java
+++ b/app/helper/WpullThread.java
@@ -27,7 +27,7 @@ public class WpullThread extends Thread {
 	private File crawlDir = null;
 	private File outDir = null;
 	private String warcFilename = null;
-	private String host = null;
+	private String host = null; /* = domain */
 	private String localpath = null;
 	private String executeCommand = null;
 	/**
@@ -202,8 +202,7 @@ public class WpullThread extends Thread {
 				executeCommand += " --hostnames=" + host;
 				for (int i = 0; i < domains.size(); i++) {
 					zusDomain = domains.get(i);
-					zusHost = zusDomain.replaceAll("^http://", "")
-							.replaceAll("^https://", "").replaceAll("/.*$", "");
+					zusHost = WebgatherUtils.getDomain(zusDomain);
 					WebgatherLogger.debug("zusHost=" + zusHost);
 					if (zusHost.equalsIgnoreCase(host)) {
 						WebgatherLogger.debug("Es soll von der gesamten Domain " + host
@@ -248,10 +247,15 @@ public class WpullThread extends Thread {
 			WebgatherLogger.info("Webcrawl for " + conf.getName()
 					+ " exited with exitState " + exitState);
 			proc.destroy();
-			if (exitState == 0 || exitState == 4 || exitState == 7 || exitState == 8) {
+			if (exitState == 0 || exitState == 4 || exitState == 7
+					|| exitState == 8) {
 				/* der Beobachtung zufolge wird bei exitState == 7 das WARC ge-moved */
-				/* daher legen wir ab jetzt auch einen Webschnitt an. IK20250205 für TOS-1182 und TOS-1224 */
-				new Create().createWebpageVersion(node, conf, outDir, localpath);
+				/*
+				 * daher legen wir ab jetzt auch einen Webschnitt an. IK20250205 für
+				 * TOS-1182 und TOS-1224
+				 */
+				new Create().createWebpageVersion(node, conf, warcFilename, outDir,
+						localpath);
 				WebgatherLogger
 						.info("WebpageVersion für " + conf.getName() + "wurde angelegt.");
 				return;

--- a/test/HeritrixTest.java
+++ b/test/HeritrixTest.java
@@ -49,8 +49,10 @@ public class HeritrixTest {
 				String uriPath = Globals.heritrix.getUriPath(warcPath);
 				String localpath =
 						Globals.heritrixData + "/heritrix-data" + "/" + uriPath;
-				Node webpageVersion =
-						create.createWebpageVersion(webpage, conf, crawlDir, localpath);
+				String warcFilename = new File(warcPath).getName();
+
+				Node webpageVersion = create.createWebpageVersion(webpage, conf,
+						warcFilename, crawlDir, localpath);
 			}
 		});
 	}


### PR DESCRIPTION
Code für "inkrementelles Crawling"
- im Test seit ca 1/2 Jahr auf edoweb-test2 --- keine Auffälligkeiten entdeckt, weder von uns noch vom LBZ.
- soll nun auf Produktion ausgerollt werden (lt. Merkler, 2025-08-28)

- zusätzlich dazu muss die Branch TOS-1103 von to.science.scripts installiert sein --- diese ist schon mit dem Main zusammengeführt (KS, 15.08. wg. was anderem) und auf Produktion installiert.