### PR TITLE
Tosdev 17

### DIFF
--- a/app/actions/Index.java
+++ b/app/actions/Index.java
@@ -43,7 +43,16 @@ public class Index {
 		return removeFromAllIndexed(pid, type, namespace);
 	}
 
-	private static String removeFromAllIndexed(String pid, String type,
+	/**
+	 * Enternt eine Ressource aus allen Elasticsearch-Indexen
+	 * 
+	 * @param pid die PID der Ressource
+	 * @param type der contentType der Ressource, z.B. "article" oder "monograph"
+	 * @param namespace der Namespace, in dem die Ressource angelegt wurde, z.B.
+	 *          "edoweb" oder "frl"
+	 * @return eine Erfolgsmeldung
+	 */
+	public static String removeFromAllIndexed(String pid, String type,
 			String namespace) {
 		if (type == null)
 			return pid + " not deleted from index. Cause: No type available!";

--- a/app/controllers/MyUtils.java
+++ b/app/controllers/MyUtils.java
@@ -143,8 +143,8 @@ public class MyUtils extends MyController {
 	}
 
 	@ApiOperation(produces = "application/json,application/html", nickname = "removeFromIndex", value = "removeFromIndex", notes = "Removes resource to elasticsearch index", httpMethod = "DELETE")
-	public static Promise<Result> removeFromIndex(@QueryParam("pid") String pid,
-			@QueryParam("type") String contentType,
+	public static Promise<Result> removePidFromIndex(
+			@QueryParam("pid") String pid, @QueryParam("type") String contentType,
 			@QueryParam("namespace") String namespace) {
 		return new ModifyAction().call(pid, userId -> {
 			String result =

--- a/app/controllers/MyUtils.java
+++ b/app/controllers/MyUtils.java
@@ -38,6 +38,7 @@ import com.wordnik.swagger.annotations.ApiImplicitParams;
 import com.wordnik.swagger.annotations.ApiOperation;
 
 import actions.Create;
+import actions.Index;
 import authenticate.BasicAuth;
 import authenticate.User;
 import authenticate.UserDB;
@@ -137,6 +138,17 @@ public class MyUtils extends MyController {
 		return new ModifyAction().call(pid, userId -> {
 			Node node = readNodeOrNull(pid);
 			String result = index.remove(node);
+			return JsonMessage(new Message(result));
+		});
+	}
+
+	@ApiOperation(produces = "application/json,application/html", nickname = "removeFromIndex", value = "removeFromIndex", notes = "Removes resource to elasticsearch index", httpMethod = "DELETE")
+	public static Promise<Result> removeFromIndex(@QueryParam("pid") String pid,
+			@QueryParam("type") String contentType,
+			@QueryParam("namespace") String namespace) {
+		return new ModifyAction().call(pid, userId -> {
+			String result =
+					actions.Index.removeFromAllIndexed(pid, contentType, namespace);
 			return JsonMessage(new Message(result));
 		});
 	}

--- a/conf.tmpl/routes
+++ b/conf.tmpl/routes
@@ -119,6 +119,7 @@ GET /api-docs/authors 		@pl.matisoft.swagger.ApiHelpController.getResource(path 
 POST /utils/index/:pid 				controllers.MyUtils.index(pid,index?="")
 POST /utils/indexAll 				controllers.MyUtils.indexAll(index?="")
 POST /utils/reinitOaisets			controllers.MyUtils.reinitOaisets(namespace?="")
+DELETE /utils/removeFromIndex 		controllers.MyUtils.removeFromIndex(pid?="",type?="article",namespace?="")
 DELETE /utils/removeFromIndex/:pid 	controllers.MyUtils.removeFromIndex(pid)
 POST /utils/lobidify/:pid 			controllers.MyUtils.lobidify(pid,alephid?="")
 POST /utils/updateMetadata/:pid 	controllers.MyUtils.updateMetadata(pid,date?="")

--- a/conf.tmpl/routes
+++ b/conf.tmpl/routes
@@ -119,7 +119,7 @@ GET /api-docs/authors 		@pl.matisoft.swagger.ApiHelpController.getResource(path 
 POST /utils/index/:pid 				controllers.MyUtils.index(pid,index?="")
 POST /utils/indexAll 				controllers.MyUtils.indexAll(index?="")
 POST /utils/reinitOaisets			controllers.MyUtils.reinitOaisets(namespace?="")
-DELETE /utils/removeFromIndex 		controllers.MyUtils.removeFromIndex(pid?="",type?="article",namespace?="")
+DELETE /utils/removePidFromIndex 		controllers.MyUtils.removePidFromIndex(pid?="",type?="article",namespace?="")
 DELETE /utils/removeFromIndex/:pid 	controllers.MyUtils.removeFromIndex(pid)
 POST /utils/lobidify/:pid 			controllers.MyUtils.lobidify(pid,alephid?="")
 POST /utils/updateMetadata/:pid 	controllers.MyUtils.updateMetadata(pid,date?="")


### PR DESCRIPTION
Ein neuer Endpoint removePidFormIndex, mit dem man Objekte unter Angabe einer PID aus dem Elasticsearch-Index löschen kann, auch wenn dazu gar keine Fedora-Ressourcen (mehr) existieren.
Die vorhandenen  DELETE-Endpoints setzten voraus, dass es auch ein Fedora-Objekt gibt.
Der neue Endpoint benötigt außer einer PID auch den namespace (z.B. frl, edoweb) und den contentType (article, monograph, ...)