### PR TITLE
Heritrix createJob nicht nur bei Neuanlage, sondern vor jedem neuen Job

### DIFF
--- a/app/helper/Heritrix.java
+++ b/app/helper/Heritrix.java
@@ -124,8 +124,6 @@ public class Heritrix {
 	}
 
 	public File createJobDir(Gatherconf conf) {
-		// nicht nur bei Neuanlage, sondern auch, falls crawlerConf im JobDir
-		// erneuert werden muss (refresh)
 		try {
 			if (conf.getName() == null) {
 				throw new RuntimeException("The configuration has no name !");

--- a/app/helper/WebgatherUtils.java
+++ b/app/helper/WebgatherUtils.java
@@ -148,9 +148,11 @@ public class WebgatherUtils {
 					throw new HttpArchiveException(403,
 							"Webgatherer is too busy! Please try again later.");
 				}
-				if (!Globals.heritrix.jobExists(conf.getName())) {
-					Globals.heritrix.createJob(conf);
-				}
+				// if (!Globals.heritrix.jobExists(conf.getName())) {
+				// nicht nur bei Neuanlage, sondern auch, falls crawlerConf im JobDir
+				// erneuert werden muss (refresh)
+				Globals.heritrix.createJob(conf);
+				// }
 				boolean success = Globals.heritrix.teardown(conf.getName());
 				WebgatherLogger.debug("Teardown " + conf.getName() + " " + success);
 


### PR DESCRIPTION
 - damit veraltete crawler-beans.cxml im Jobverzeichnis auf den neuesten Stand gebracht werden