### PR TITLE
Dois should not be displayed as hyperlinks but as plain text.

### DIFF
--- a/app/views/tags/ktblView.scala.html
+++ b/app/views/tags/ktblView.scala.html
@@ -332,8 +332,8 @@
 		<tr class="ktbl emimin">
 		<td style="display:none;">"80"</td>
 		<td class="field-label">DOI</td>
-		<td class="field-item"><a href="https://doi.org/@node.getDoi()" target="_blank">
-			@views.KtblHelper.getDoi(node)</a>
+		<td class="field-item">
+			@views.KtblHelper.getDoi(node)
 		</td>
 		</tr>
 	}


### PR DESCRIPTION
Die DOIs( in Ktbl) sollen als einfache Texte angezeigt werden und nicht mehr als anklickbare Hyperlinks, die auf sich selbst verweisen. 