### PR TITLE
Make uploadUpdateMetadata less dependent on frl content types

### DIFF
--- a/app/controllers/Resource.java
+++ b/app/controllers/Resource.java
@@ -600,7 +600,7 @@ public class Resource extends MyController {
 				 * 1.KTBL(Json)***************************************
 				 */
 
-				String content = KTBLMapperHelper.getFileData(data);
+				String content = TosHelper.getFileData(data);
 
 				if (KTBLMapperHelper.containsKtblBlock(content)) {
 					play.Logger.debug("Starting KTBL Mapping");

--- a/app/controllers/Resource.java
+++ b/app/controllers/Resource.java
@@ -1721,12 +1721,22 @@ public class Resource extends MyController {
 				/**
 				 * toscience
 				 */
-				if (contentType.equals("article") || contentType.equals("researchData")
-						|| contentType.equals("ktbl")) {
-					/*
-					 * Das scheint mir speziell für diese Content Types zu sein, und damit
-					 * speziell für frl
-					 */
+				if (contentType.equals("monograph") || contentType.equals("journal")
+						|| contentType.equals("webpage")) {
+
+					tosJson =
+							TosHelper.getLobidMonographAsJson(content, readNode.getPid());
+
+					if (tosJson == null) {
+						play.Logger.debug("Invalid" + contentType + " MD");
+						return (Result) JsonMessage(new Message("Invalid MD", 400));
+					}
+
+					tosJson = TosHelper.validateJsonStructure(tosJson, readNode);
+
+				} else {
+					/* z.B. Article, researchData, ktbl, WebsiteVersion */
+
 					content = TosHelper.updateConent(content);
 
 					if (content == null || !TosHelper.isValidJson(content)) {
@@ -1739,19 +1749,6 @@ public class Resource extends MyController {
 					String tosMd =
 							TosHelper.getToPersistTosMd(content, readNode.getPid());
 					tosJson = new JSONObject(tosMd);
-
-				} else {
-					// Standard-Behandlung, für alle anderen Content Types
-
-					tosJson =
-							TosHelper.getLobidMonographAsJson(content, readNode.getPid());
-
-					if (tosJson == null) {
-						play.Logger.debug("Invalid" + contentType + " MD");
-						return (Result) JsonMessage(new Message("Invalid MD", 400));
-					}
-
-					tosJson = TosHelper.validateJsonStructure(tosJson, readNode);
 
 				}
 

--- a/app/controllers/Resource.java
+++ b/app/controllers/Resource.java
@@ -1688,13 +1688,13 @@ public class Resource extends MyController {
 			@PathParam("pid") String pid) {
 		return new ModifyAction().call(pid, node -> {
 
-			play.Logger.debug("*****uploadUpdateMetadata has been called*****");
+			play.Logger.debug("START uploadUpdateMetadata");
 			try {
 				Node readNode = readNodeOrNull(pid);
 				JSONObject tosJson = null;
 				String result1 = null, result2 = null, result3 = null, content = null;
 				LinkedHashMap<String, Object> rdf = null;
-				String conType = readNode.getContentType();
+				String contentType = readNode.getContentType();
 
 				MultipartFormData body = request().body().asMultipartFormData();
 				if (body == null) {
@@ -1706,70 +1706,84 @@ public class Resource extends MyController {
 					return (Result) JsonMessage(new Message("Missing File.", 400));
 				}
 
-				if (!conType.contains("file") && !conType.contains("part")) {
-					content = KTBLMapperHelper.getFileData(data);
+				if (contentType.contains("file") || contentType.contains("part")) {
+					return JsonMessage(new Message(
+							"files and parts are not applicable for upload metadata.", 400));
+				}
 
-					if (!TosHelper.isValidJson(content)) {
-						play.Logger.debug("Invalid content");
-						return (Result) JsonMessage(new Message("Invalid content", 400));
-					}
+				content = TosHelper.getFileData(data);
 
-					// Monographs
-					if ("monograph".equals(conType)) {
-						tosJson =
-								TosHelper.getLobidMonographAsJson(content, readNode.getPid());
+				if (!TosHelper.isValidJson(content)) {
+					play.Logger.debug("Invalid content");
+					return (Result) JsonMessage(new Message("Invalid content", 400));
+				}
 
-						if (tosJson == null) {
-							play.Logger.debug("Invalid" + conType + " MD");
-							return (Result) JsonMessage(new Message("Invalid MD", 400));
-						}
-
-						tosJson = TosHelper.validateJsonStructure(tosJson, readNode);
-						tosJson = TosHelper.getPrefLabelsResolved(tosJson);
-						result1 = modify.updateMetadata("toscience", readNode,
-								tosJson.toString());
-
-						// KTBL, Article and ResearchData
-					} else {
-						content = TosHelper.updateConent(content);
-						if (content == null || !TosHelper.isValidJson(content)) {
-							play.Logger.debug("Invalid" + conType + " MD");
-							return (Result) JsonMessage(new Message("Invalid MD", 400));
-						}
-
-						// Data streams (Persist or update)
-
-						/**
-						 * toscience
-						 */
-						String tosMd =
-								TosHelper.getToPersistTosMd(content, readNode.getPid());
-						tosJson = new JSONObject(tosMd);
-						tosJson = TosHelper.getPrefLabelsResolved(tosJson);
-						result1 = modify.updateMetadata("toscience", readNode,
-								tosJson.toString());
-					}
-
-					/**
-					 * KTBL
+				/**
+				 * toscience
+				 */
+				if (contentType.equals("article") || contentType.equals("researchData")
+						|| contentType.equals("ktbl")) {
+					/*
+					 * Das scheint mir speziell für diese Content Types zu sein, und damit
+					 * speziell für frl
 					 */
-					if (KTBLMapperHelper.containsKtblBlock(content)) {
-						String ktblMd =
-								KTBLMapperHelper.getToPersistKtblMd(content, readNode.getPid());
-						result2 = modify.updateMetadata("ktbl", readNode, ktblMd);
+					content = TosHelper.updateConent(content);
+
+					if (content == null || !TosHelper.isValidJson(content)) {
+						play.Logger.debug("Invalid" + contentType + " MD");
+						return (Result) JsonMessage(new Message("Invalid MD", 400));
 					}
 
-					/**
-					 * Metadata2
-					 */
-					rdf = Metadata2Helper.getRdfFromTos(tosJson, readNode);
-					String rdfMd = modify.rdfToString(
-							(Map<String, Object>) rdf.get("metadata2"), RDFFormat.NTRIPLES);
-					result3 = modify.updateMetadata("metadata2", readNode, rdfMd);
-					Enrich.enrichMetadata2(readNode);
+					// Data streams (Persist or update)
+
+					String tosMd =
+							TosHelper.getToPersistTosMd(content, readNode.getPid());
+					tosJson = new JSONObject(tosMd);
+
+				} else {
+					// Standard-Behandlung, für alle anderen Content Types
+
+					tosJson =
+							TosHelper.getLobidMonographAsJson(content, readNode.getPid());
+
+					if (tosJson == null) {
+						play.Logger.debug("Invalid" + contentType + " MD");
+						return (Result) JsonMessage(new Message("Invalid MD", 400));
+					}
+
+					tosJson = TosHelper.validateJsonStructure(tosJson, readNode);
 
 				}
-				return JsonMessage(new Message(result1 + result2 + result3));
+
+				tosJson = TosHelper.getPrefLabelsResolved(tosJson);
+				result1 =
+						modify.updateMetadata("toscience", readNode, tosJson.toString());
+
+				/**
+				 * KTBL
+				 */
+				if (KTBLMapperHelper.containsKtblBlock(content)) {
+					String ktblMd =
+							KTBLMapperHelper.getToPersistKtblMd(content, readNode.getPid());
+					result2 = modify.updateMetadata("ktbl", readNode, ktblMd);
+				}
+
+				/**
+				 * Metadata2
+				 */
+				rdf = Metadata2Helper.getRdfFromTos(tosJson, readNode);
+				String rdfMd = modify.rdfToString(
+						(Map<String, Object>) rdf.get("metadata2"), RDFFormat.NTRIPLES);
+				result3 = modify.updateMetadata("metadata2", readNode, rdfMd);
+				Enrich.enrichMetadata2(readNode);
+
+				String msg = result1;
+				if (result2 != null)
+					msg = msg + result2;
+				if (result3 != null)
+					msg = msg + result3;
+				return JsonMessage(new Message(msg));
+
 			} catch (Exception e) {
 				throw new HttpArchiveException(500, e);
 			}

--- a/app/controllers/Resource.java
+++ b/app/controllers/Resource.java
@@ -1706,7 +1706,8 @@ public class Resource extends MyController {
 					return (Result) JsonMessage(new Message("Missing File.", 400));
 				}
 
-				if (contentType.contains("file") || contentType.contains("part")) {
+				if (contentType.contains("file") || contentType.contains("part")
+						|| contentType.contains("version")) {
 					return JsonMessage(new Message(
 							"files and parts are not applicable for upload metadata.", 400));
 				}
@@ -1735,7 +1736,7 @@ public class Resource extends MyController {
 					tosJson = TosHelper.validateJsonStructure(tosJson, readNode);
 
 				} else {
-					/* z.B. Article, researchData, ktbl, WebsiteVersion */
+					/* article, researchData, ktbl */
 
 					content = TosHelper.updateConent(content);
 

--- a/app/helper/KTBLMapperHelper.java
+++ b/app/helper/KTBLMapperHelper.java
@@ -23,45 +23,6 @@ import org.json.JSONArray;
 public class KTBLMapperHelper {
 
 	/**
-	 * This method gets the content of a FilePart(Json File) and returns it as a
-	 * string
-	 * 
-	 * @param fp
-	 * @return the content of the file as a string
-	 */
-	static public String getFileData(FilePart fp) {
-		StringBuilder ktblMetadata = null;
-		BufferedReader br = null;
-
-		try {
-			ktblMetadata = new StringBuilder();
-			if (fp != null) {
-				File file = (File) fp.getFile();
-				br = new BufferedReader(new FileReader(file));
-				String line;
-				while ((line = br.readLine()) != null) {
-					ktblMetadata.append(line);
-				}
-			}
-		} catch (FileNotFoundException e) {
-			play.Logger.debug("Exception in getFileData(), File not found");
-			return null;
-		} catch (IOException e) {
-			play.Logger.debug("Exception in getFileData()" + e);
-			return null;
-		} finally {
-			if (br != null) {
-				try {
-					br.close();
-				} catch (IOException e) {
-				}
-			}
-		}
-		play.Logger.debug("ktblMetadata.toString()=" + ktblMetadata.toString());
-		return ktblMetadata.toString();
-	}
-
-	/**
 	 * The method gets the required KTBL metadata from the json file and returns
 	 * it as a string
 	 * 

--- a/app/helper/TosHelper.java
+++ b/app/helper/TosHelper.java
@@ -7,6 +7,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -24,6 +29,8 @@ import models.Node;
 import java.util.stream.Collectors;
 import org.json.JSONException;
 import play.Play;
+import play.mvc.Http.MultipartFormData.FilePart;
+
 import org.eclipse.rdf4j.rio.RDFFormat;
 import views.Helper;
 
@@ -1581,4 +1588,44 @@ public class TosHelper {
 	public static boolean isLike(JSONObject j1, JSONObject j2) {
 		return j1.toString().equals(j2.toString());
 	}
+
+	/**
+	 * This method gets the content of a FilePart (Json File) and returns it as a
+	 * string
+	 * 
+	 * @param fp a FilePart
+	 * @return the content of the file as a string
+	 */
+	static public String getFileData(FilePart fp) {
+		StringBuilder metadata = null;
+		BufferedReader br = null;
+
+		try {
+			metadata = new StringBuilder();
+			if (fp != null) {
+				File file = (File) fp.getFile();
+				br = new BufferedReader(new FileReader(file));
+				String line;
+				while ((line = br.readLine()) != null) {
+					metadata.append(line);
+				}
+			}
+		} catch (FileNotFoundException e) {
+			play.Logger.debug("Exception in getFileData(), File not found");
+			return null;
+		} catch (IOException e) {
+			play.Logger.debug("Exception in getFileData()" + e);
+			return null;
+		} finally {
+			if (br != null) {
+				try {
+					br.close();
+				} catch (IOException e) {
+				}
+			}
+		}
+		play.Logger.debug("metadata.toString()=" + metadata.toString());
+		return metadata.toString();
+	}
+
 }


### PR DESCRIPTION
Hi @hadoud ! Deine Implementation von uploadUpdateMetadata erscheint mir zu sehr spezifisch für die KTBL Inhaltstypen zu sein. Z.B. für Webpages und für Journals würde es so nicht funktionieren. 
Ich habe es einmal umgeschrieben, so dass ich meine, wie es auch für andere Content Types passen könnte.
Dies in einer neuen Branch newJson2MappingWithWebpages.
Bitte schaue es Dir einmal an und merge es dann ggfs. in deine Branch (dadurch würde es dann auch in deinen Pull Request hinein kommen).
Viele Grüße
Ingolf